### PR TITLE
Remove almost all unsafe code and fixed a memory leak in `Evtree`

### DIFF
--- a/examples/ism/src/main.rs
+++ b/examples/ism/src/main.rs
@@ -130,7 +130,8 @@ impl ISM {
 
 
     fn read_data(back: usize) -> Self {
-        let mut reader = csv::Reader::from_path("C:/Users/pkalivas/Desktop/radiate/examples/ism/src/ism_input.csv").unwrap();
+        let csv_data = include_bytes!("ism_input.csv");
+        let mut reader = csv::Reader::from_reader(&csv_data[..]);
         let mut data = Vec::new();
         for result in reader.records() {
             let temp = result.unwrap();
@@ -158,7 +159,7 @@ impl ISM {
 
 
     fn write_data(&self, solution: &mut Neat) {
-        let mut writer = csv::Writer::from_path("C:/Users/pkalivas/Desktop/radiate/examples/ism/src/ism.csv").unwrap();
+        let mut writer = csv::Writer::from_path("ism.csv").unwrap();
         for (i, o) in self.inputs.iter().zip(self.answers.iter()) {
             let guess = solution.forward(i).unwrap();
             writer.write_record(&[

--- a/examples/ism/src/main.rs
+++ b/examples/ism/src/main.rs
@@ -5,10 +5,6 @@ extern crate rayon;
 
 use std::error::Error;
 use radiate::prelude::*;
-use rayon::prelude::*;
-
-
-
 
 fn main() -> Result<(), Box<dyn Error>> {
 
@@ -180,6 +176,7 @@ impl ISM {
     }
 
 
+    #[allow(dead_code)]
     fn show(&self, model: &mut Neat) {
         println!("\n");
         for (i, o) in self.inputs.iter().zip(self.answers.iter()) {
@@ -196,9 +193,10 @@ impl ISM {
     }
 
 
+    #[allow(dead_code)]
     fn freestyle(&self, num: usize, model: &mut Neat) {
         let mut guess = Vec::new();
-        for (i, o) in self.inputs.iter().zip(self.answers.iter()) {
+        for (i, _o) in self.inputs.iter().zip(self.answers.iter()) {
             guess = model.forward(i).unwrap();
         }
 
@@ -213,12 +211,6 @@ impl ISM {
 
 
 }
-
-
-unsafe impl Send for ISM {}
-unsafe impl Sync for ISM {}
-
-
 
 
 impl Problem<Neat> for ISM {

--- a/examples/lstm-neat/src/main.rs
+++ b/examples/lstm-neat/src/main.rs
@@ -25,7 +25,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         ]);
         
     let num_evolve = 200;
-    let num_train = 0;
 
     let data = MemoryTest::new();
     let starting_net = Neat::new()
@@ -53,6 +52,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             num == num_evolve
         })?;
         
+    //let num_train = 0;
         // solution.train(&data.input, &data.output, 0.01, Loss::Diff, |iter, loss| {
         //     let temp = format!("{:.6}", loss).parse::<f32>().unwrap().abs();
         //     println!("epoch: {:?} loss: {:.6?}", iter, temp);
@@ -115,10 +115,6 @@ impl MemoryTest {
         println!("Input: {:?}, Expecting: {:?}, Guess: {:.2}", vec![0.0], vec![1.0], model.forward(&vec![0.0]).unwrap()[0]);
     }
 }
-
-
-unsafe impl Send for MemoryTest {}
-unsafe impl Sync for MemoryTest {}
 
 
 impl Problem<Neat> for MemoryTest {

--- a/examples/neat-web/neat-client/src/main.rs
+++ b/examples/neat-web/neat-client/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), reqwest::Error> {
     let client = reqwest::Client::new();
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-    let res = client.post("http://0.0.0.0:42069/")
+    let _res = client.post("http://0.0.0.0:42069/")
         .headers(headers)
         .body(data)
         .send().await;  

--- a/examples/xor-evtree/src/main.rs
+++ b/examples/xor-evtree/src/main.rs
@@ -71,12 +71,6 @@ impl XOR {
 }
 
 
-unsafe impl Send for XOR {}
-unsafe impl Sync for XOR {}
-
-
-
-
 impl Problem<Evtree> for XOR {
 
     fn empty() -> Self { XOR::new() }

--- a/examples/xor-neat/src/main.rs
+++ b/examples/xor-neat/src/main.rs
@@ -103,11 +103,6 @@ impl XOR {
 }
 
 
-unsafe impl Send for XOR {}
-unsafe impl Sync for XOR {}
-
-
-
 
 impl Problem<Neat> for XOR {
 

--- a/radiate/src/models/README.md
+++ b/radiate/src/models/README.md
@@ -181,10 +181,6 @@ impl MemoryTest {
 }
 
 
-unsafe impl Send for MemoryTest {}
-unsafe impl Sync for MemoryTest {}
-
-
 impl Problem<Neat> for MemoryTest {
 
     fn empty() -> Self { MemoryTest::new() }

--- a/radiate/src/models/neat/edge.rs
+++ b/radiate/src/models/neat/edge.rs
@@ -45,7 +45,7 @@ impl Edge {
 
     /// calculate the eligibility of this connection and store it for time series predictions
     #[inline]
-    pub fn calculate(&mut self, val: f32) -> f32 {
+    pub fn calculate(&self, val: f32) -> f32 {
         val * self.weight
     }
     

--- a/radiate/src/models/neat/layers/dense.rs
+++ b/radiate/src/models/neat/layers/dense.rs
@@ -42,10 +42,20 @@ pub struct Dense {
 }
 
 
+/// Helper function.  Convert pointer to mutable reference.
+fn to_mut_ref(node: &*mut Neuron) -> &mut Neuron {
+    unsafe { &mut **node }
+}
+
+/// Helper function.  Convert pointer to reference.
+fn to_ref(node: &*mut Neuron) -> &Neuron {
+    unsafe { &**node }
+}
+
+
 
 impl Dense {
 
-    
     /// create a new fully connected dense layer.
     /// Each input is connected to each output with a randomly generated weight attached to the connection
     #[inline]
@@ -72,17 +82,15 @@ impl Dense {
         for innov in layer.outputs.iter() {
             layer.nodes.insert(*innov, Neuron::new(*innov, NeuronType::Output, activation, NeuronDirection::Forward).as_mut_ptr());
         }
-        
+
         let mut r = rand::thread_rng();
-        unsafe {
-            for i in layer.inputs.iter() {
-                for j in layer.outputs.iter() {
-                    let weight = r.gen::<f32>() * 2.0 - 1.0;
-                    let new_edge = Edge::new(*i, *j, Uuid::new_v4(), weight, true);
-                    layer.nodes.get(i).map(|x| (**x).outgoing.push(new_edge.innov));
-                    layer.nodes.get(j).map(|x| (**x).incoming.insert(new_edge.innov, None));
-                    layer.edges.insert(new_edge.innov, new_edge);
-                }
+        for i in layer.inputs.iter() {
+            for j in layer.outputs.iter() {
+                let weight = r.gen::<f32>() * 2.0 - 1.0;
+                let new_edge = Edge::new(*i, *j, Uuid::new_v4(), weight, true);
+                layer.get_node_mut(i).map(|x| x.outgoing.push(new_edge.innov));
+                layer.get_node_mut(j).map(|x| x.incoming.insert(new_edge.innov, None));
+                layer.edges.insert(new_edge.innov, new_edge);
             }
         }
 
@@ -90,15 +98,18 @@ impl Dense {
     }
 
 
+    fn get_node_mut(&self, id: &Uuid) -> Option<&mut Neuron> {
+        self.nodes.get(&id).map(to_mut_ref)
+    }
 
     /// reset all the neurons in the network so they can be fed forward again
     #[inline]
-    unsafe fn reset_neurons(&self) {
-        for val in self.nodes.values() {
-            (**val).reset_neuron();
+    fn reset_neurons(&self) {
+        for val in self.nodes.values().map(to_mut_ref) {
+            val.reset_neuron();
         }
-    }   
-    
+    }
+
 
 
     /// get the outputs from the layer in a vec form
@@ -107,7 +118,7 @@ impl Dense {
         let result = self.outputs
             .iter()
             .map(|x| {
-                unsafe { (**self.nodes.get(x).unwrap()).activated_value }
+                self.get_node_mut(x).unwrap().activated_value
             })
             .collect::<Vec<_>>();
         Some(result)
@@ -122,39 +133,37 @@ impl Dense {
     /// old source node and the new node
     #[inline]
     pub fn add_node(&mut self, activation: Activation, direction: NeuronDirection) {
-        unsafe {
-            // create a new node to insert inbetween the sending and receiving nodes 
-            let new_node = Neuron::new(Uuid::new_v4(), NeuronType::Hidden, activation, direction).as_mut_ptr();
+        // create a new node to insert inbetween the sending and receiving nodes 
+        let mut new_node = Neuron::new(Uuid::new_v4(), NeuronType::Hidden, activation, direction);
 
-            // get an edge to insert the node into
-            // get the sending and receiving nodes from the edge
-            let curr_edge = self.edges.get_mut(&self.random_edge()).unwrap();
-            let sending = self.nodes.get(&curr_edge.src).unwrap();
-            let receiving = self.nodes.get(&curr_edge.dst).unwrap();
-            
-            // create two new edges that connect the src and the new node and the 
-            // new node and dst, then disable the current edge 
-            curr_edge.active = false;
-            let incoming = Edge::new((**sending).innov, (*new_node).innov, Uuid::new_v4(), 1.0, true);
-            let outgoing = Edge::new((*new_node).innov, (**receiving).innov, Uuid::new_v4(), curr_edge.weight, true);
-            
-            // remove the outgoing connection from the sending node
-            (**sending).outgoing.retain(|x| x != &(curr_edge.innov));
-            (**receiving).incoming.remove(&curr_edge.innov);
-            
-            // add the new values
-            (**sending).outgoing.push(incoming.innov);
-            (**receiving).incoming.insert(outgoing.innov, None);
-            
-            // add the vlaues to the new node
-            (*new_node).outgoing.push(outgoing.innov);
-            (*new_node).incoming.insert(incoming.innov, None);
-            
-            // add the new nodes and the new edges to the network
-            self.edges.insert(incoming.innov, incoming);
-            self.edges.insert(outgoing.innov, outgoing);
-            self.nodes.insert((*new_node).innov, new_node);   
-        }
+        // get an edge to insert the node into
+        // get the sending and receiving nodes from the edge
+        let curr_edge = self.edges.get_mut(&self.random_edge()).unwrap();
+        let sending = self.nodes.get(&curr_edge.src).map(to_mut_ref).unwrap();
+        let receiving = self.nodes.get(&curr_edge.dst).map(to_mut_ref).unwrap();
+
+        // create two new edges that connect the src and the new node and the 
+        // new node and dst, then disable the current edge 
+        curr_edge.active = false;
+        let incoming = Edge::new(sending.innov, new_node.innov, Uuid::new_v4(), 1.0, true);
+        let outgoing = Edge::new(new_node.innov, receiving.innov, Uuid::new_v4(), curr_edge.weight, true);
+
+        // remove the outgoing connection from the sending node
+        sending.outgoing.retain(|x| x != &(curr_edge.innov));
+        receiving.incoming.remove(&curr_edge.innov);
+
+        // add the new values
+        sending.outgoing.push(incoming.innov);
+        receiving.incoming.insert(outgoing.innov, None);
+
+        // add the vlaues to the new node
+        new_node.outgoing.push(outgoing.innov);
+        new_node.incoming.insert(incoming.innov, None);
+
+        // add the new nodes and the new edges to the network
+        self.edges.insert(incoming.innov, incoming);
+        self.edges.insert(outgoing.innov, outgoing);
+        self.nodes.insert(new_node.innov, new_node.as_mut_ptr());
     }
 
 
@@ -165,34 +174,31 @@ impl Dense {
     /// with a weight of .5 in order to minimally impact the network 
     #[inline]
     pub fn add_edge(&mut self) {
-        unsafe {
-            // get a valid sending neuron
-            let sending = loop {
-                let temp = self.nodes.get(&self.random_node()).unwrap();
-                if (**temp).neuron_type != NeuronType::Output {
-                    break temp;
-                }
-            };
-            // get a vaild receiving neuron
-            let receiving = loop {
-                let temp = self.nodes.get(&self.random_node()).unwrap();
-                if (**temp).neuron_type != NeuronType::Input {
-                    break temp;
-                }
-            };
-
-            // determine if the connection to be made is valid 
-            if self.valid_connection(sending, receiving) {
-               
-                // if the connection is valid, make it and wire the nodes to each
-                let mut r = rand::thread_rng();
-                let new_edge = Edge::new((**sending).innov, (**receiving).innov, Uuid::new_v4(), r.gen::<f32>(), true);
-                (**sending).outgoing.push(new_edge.innov);
-                (**receiving).incoming.insert(new_edge.innov, None);
-            
-                // add the new edge to the network
-                self.edges.insert(new_edge.innov, new_edge);               
+        // get a valid sending neuron
+        let sending = loop {
+            let temp = self.get_node_mut(&self.random_node()).unwrap();
+            if temp.neuron_type != NeuronType::Output {
+                break temp;
             }
+        };
+        // get a vaild receiving neuron
+        let receiving = loop {
+            let temp = self.get_node_mut(&self.random_node()).unwrap();
+            if temp.neuron_type != NeuronType::Input {
+                break temp;
+            }
+        };
+
+        // determine if the connection to be made is valid 
+        if self.valid_connection(sending, receiving) {
+            // if the connection is valid, make it and wire the nodes to each
+            let mut r = rand::thread_rng();
+            let new_edge = Edge::new(sending.innov, receiving.innov, Uuid::new_v4(), r.gen::<f32>(), true);
+            sending.outgoing.push(new_edge.innov);
+            receiving.incoming.insert(new_edge.innov, None);
+
+            // add the new edge to the network
+            self.edges.insert(new_edge.innov, new_edge);
         }
     }
 
@@ -204,7 +210,7 @@ impl Dense {
     /// 3.) the desired connection would create a cycle in the graph
     /// if these are all false, then the connection can be made
     #[inline]
-    unsafe fn valid_connection(&self, sending: &*mut Neuron, receiving: &*mut Neuron) -> bool {
+    fn valid_connection(&self, sending: &Neuron, receiving: &Neuron) -> bool {
         if sending == receiving {
             return false
         } else if self.exists(sending, receiving) {
@@ -220,23 +226,22 @@ impl Dense {
     /// check to see if the connection to be made would create a cycle in the graph
     /// and therefore make it network invalid and unable to feed forward
     #[inline]
-    unsafe fn cyclical(&self, sending: &*mut Neuron, receiving: &*mut Neuron) -> bool {
+    fn cyclical(&self, sending: &Neuron, receiving: &Neuron) -> bool {
         // dfs stack which gets the receiving Neuron<dyn neurons> outgoing connections
-        let mut stack = (**receiving).outgoing
+        let mut stack = receiving.outgoing
             .iter()
             .map(|x| self.edges.get(x).unwrap().dst)
             .collect::<Vec<_>>();
-       
+
         // while the stack still has nodes, continue
         while stack.len() > 0 {
-            
             // if the current node is the same as the sending, this would cause a cycle
             // else add all the current node's outputs to the stack to search through
-            let curr = self.nodes.get(&stack.pop().unwrap()).unwrap();
+            let curr = self.get_node_mut(&stack.pop().unwrap()).unwrap();
             if curr == sending {
                 return true;
             }
-            for i in (**curr).outgoing.iter() {
+            for i in curr.outgoing.iter() {
                 stack.push(self.edges.get(i).unwrap().dst);
             }
         }
@@ -248,9 +253,9 @@ impl Dense {
     /// check if the desired connection already exists within he network, if it does then
     /// we should not be creating the connection.
     #[inline]
-    unsafe fn exists(&self, sending: &*mut Neuron, receiving: &*mut Neuron) -> bool {
+    fn exists(&self, sending: &Neuron, receiving: &Neuron) -> bool {
         for val in self.edges.values() {
-            if val.src == (**sending).innov && val.dst == (**receiving).innov {
+            if val.src == sending.innov && val.dst == receiving.innov {
                 return true
             }
         }
@@ -295,13 +300,13 @@ impl Dense {
     /// that holds the innovation numbers of the input nodes for a dfs traversal 
     /// to feed forward those inputs through the network
     #[inline]
-    unsafe fn give_inputs(&mut self, data: &Vec<f32>) -> Vec<Uuid> {
+    fn give_inputs(&mut self, data: &Vec<f32>) -> Vec<Uuid> {
         assert!(data.len() == self.inputs.len());
         let mut ids = Vec::with_capacity(self.inputs.len());
         for (node_innov, input) in self.inputs.iter().zip(data.iter()) {
-            let node = self.nodes.get(node_innov).unwrap();
-            (**node).activated_value = *input;
-            ids.push((**node).innov);
+            let node = self.get_node_mut(node_innov).unwrap();
+            node.activated_value = *input;
+            ids.push(node.innov);
         }
         ids
     }
@@ -320,13 +325,11 @@ impl Dense {
                 edge.weight *= r.gen_range(-size, size);
             }
         }
-        for node in self.nodes.values() {
-            unsafe {
-                if r.gen::<f32>() < editable {
-                    (**node).bias = r.gen::<f32>();
-                } else {
-                    (**node).bias *= r.gen_range(-size, size);
-                }
+        for node in self.nodes.values().map(to_mut_ref) {
+            if r.gen::<f32>() < editable {
+                node.bias = r.gen::<f32>();
+            } else {
+                node.bias *= r.gen_range(-size, size);
             }
         }
     }
@@ -340,10 +343,8 @@ impl Dense {
         self.outputs
             .iter()
             .map(|x| {
-                unsafe {
-                    let output_neuron = self.nodes.get(x).unwrap();
-                    (**output_neuron).current_state
-                }
+                let output_neuron = self.get_node_mut(x).unwrap();
+                output_neuron.current_state
             })
             .collect::<Vec<_>>()
     }
@@ -368,11 +369,9 @@ impl Dense {
             }
         };
         for (i, neuron_id) in self.outputs.iter().enumerate() {
-            unsafe {
-                let curr_neuron = self.nodes.get(neuron_id).unwrap();
-                (**curr_neuron).activated_value = act[i];
-                (**curr_neuron).deactivated_value = d_act[i];
-            }
+            let curr_neuron = self.get_node_mut(neuron_id).unwrap();
+            curr_neuron.activated_value = act[i];
+            curr_neuron.deactivated_value = d_act[i];
         }
     }
 
@@ -382,13 +381,12 @@ impl Dense {
     #[inline]
     pub fn update_traces(&mut self) {
         if let Some(tracer) = &mut self.trace_states {
-            unsafe {
-                for (n_id, n_ptr) in self.nodes.iter() {
-                    tracer.update_neuron_activation(n_id, (**n_ptr).activated_value);
-                    tracer.update_neuron_derivative(n_id, (**n_ptr).deactivated_value);
-                }
-                tracer.index += 1;
+            for (n_id, n_ptr) in self.nodes.iter() {
+                let n = to_mut_ref(n_ptr);
+                tracer.update_neuron_activation(n_id, n.activated_value);
+                tracer.update_neuron_derivative(n_id, n.deactivated_value);
             }
+            tracer.index += 1;
         }
     }
 
@@ -405,52 +403,50 @@ impl Layer for Dense {
     /// wrong within the feed forward process.
     #[inline]
     fn forward(&mut self, data: &Vec<f32>) -> Option<Vec<f32>> {
-        unsafe {
-            // reset the network by clearing the previous outputs from the neurons 
-            // this could be done more efficently if i didn't want to implement backprop
-            // or recurent nodes, however this must be done this way in order to allow for the 
-            // needed values for those algorithms to remain while they are needed 
-            // give the input data to the input neurons and return back 
-            // a stack to do a graph traversal to feed the inputs through the network
-            self.reset_neurons();
-            let mut path = self.give_inputs(data);
+        // reset the network by clearing the previous outputs from the neurons 
+        // this could be done more efficently if i didn't want to implement backprop
+        // or recurent nodes, however this must be done this way in order to allow for the 
+        // needed values for those algorithms to remain while they are needed 
+        // give the input data to the input neurons and return back 
+        // a stack to do a graph traversal to feed the inputs through the network
+        self.reset_neurons();
+        let mut path = self.give_inputs(data);
 
-            // while the path is still full, continue feeding forward 
-            // the data in the network, this is basically a dfs traversal
-            while path.len() > 0 {
-            
-                // remove the top elemet to propagate it's value
-                let curr_node = self.nodes.get(&path.pop()?)?;
-            
-                // no node should be in the path if it's value has not been set 
-                // iterate through the current nodes outgoing connections 
-                // to get its value and give that value to it's connected node
-                for edge_innov in (**curr_node).outgoing.iter() {
-        
-                    // if the currnet edge is active in the network, we can propagate through it
-                    let curr_edge = self.edges.get_mut(edge_innov)?;
-                    if curr_edge.active {
-                        let receiving_node = self.nodes.get(&curr_edge.dst)?;
-                        let activated_value = curr_edge.calculate((**curr_node).activated_value);
-                        (**receiving_node).incoming.insert(curr_edge.innov, Some(activated_value));
-        
-                        // if the node can be activated, activate it and store it's value
-                        // only activated nodes can be added to the path, so if it's activated
-                        // add it to the path so the values can be propagated through the network
-                        if (**receiving_node).is_ready() {
-                            (**receiving_node).activate();
-                            path.push((**receiving_node).innov);
-                        }
+        // while the path is still full, continue feeding forward 
+        // the data in the network, this is basically a dfs traversal
+        while path.len() > 0 {
+
+            // remove the top elemet to propagate it's value
+            let curr_node = self.nodes.get(&path.pop()?).map(to_mut_ref)?;
+
+            // no node should be in the path if it's value has not been set 
+            // iterate through the current nodes outgoing connections 
+            // to get its value and give that value to it's connected node
+            for edge_innov in curr_node.outgoing.iter() {
+
+                // if the currnet edge is active in the network, we can propagate through it
+                let curr_edge = self.edges.get_mut(edge_innov)?;
+                if curr_edge.active {
+                    let receiving_node = self.nodes.get(&curr_edge.dst).map(to_mut_ref)?;
+                    let activated_value = curr_edge.calculate(curr_node.activated_value);
+                    receiving_node.incoming.insert(curr_edge.innov, Some(activated_value));
+
+                    // if the node can be activated, activate it and store it's value
+                    // only activated nodes can be added to the path, so if it's activated
+                    // add it to the path so the values can be propagated through the network
+                    if receiving_node.is_ready() {
+                        receiving_node.activate();
+                        path.push(receiving_node.innov);
                     }
                 }
             }
-            
-            // once we've made it through the network, the outputs should all
-            // have calculated their values. Gather the values and return the vec
-            self.set_output_values();
-            self.update_traces();
-            self.get_outputs()
         }
+
+        // once we've made it through the network, the outputs should all
+        // have calculated their values. Gather the values and return the vec
+        self.set_output_values();
+        self.update_traces();
+        self.get_outputs()
     }
 
 
@@ -462,75 +458,72 @@ impl Layer for Dense {
         // feed forward the input data to get the output in order to compute the error of the network
         // create a dfs stack to step backwards through the network and compute the error of each neuron
         // then insert that error in a hashmap to keep track of innov of the neuron and it's error 
-        unsafe  {
             let mut path = self.outputs
                 .iter()
                 .enumerate()
                 .map(|(index, innov)| {
-                    let node = self.nodes.get(innov).unwrap();
-                    (**node).error = error[index];
+                    let node = self.nodes.get(innov).map(to_mut_ref).unwrap();
+                    node.error = error[index];
                     *innov
                 })
                 .collect::<Vec<_>>();
 
-            // step through the network backwards and adjust the weights
-            while path.len() > 0 {
-              
-                // get the current node and it's error 
-                let curr_node = self.nodes.get(&path.pop()?)?;
-                let step = match &self.trace_states {
-                    Some(tracer) => (**curr_node).error * tracer.neuron_derivative((**curr_node).innov),
-                    None => (**curr_node).error * (**curr_node).deactivated_value
-                } * learning_rate;
-              
-                // iterate through each of the incoming edes to this neuron and adjust it's weight
-                // and add it's error to the errros map
-                for incoming_edge_innov in (**curr_node).incoming.keys() {
-                    let curr_edge = self.edges.get_mut(incoming_edge_innov)?;
-              
-                    // if the current edge is active, then it is contributing to the error and we need to adjust it
-                    if curr_edge.active {
-                        let src_neuron = self.nodes.get(&curr_edge.src)?;
-              
-                        // add the weight step (gradient) * the currnet value to the weight to adjust the weight
-                        // then update the connection so it knows if it should update the weight, or store the delta
-                        let delta = match &self.trace_states {
-                            Some(tracer) => step * tracer.neuron_activation((**src_neuron).innov),
-                            None => step * (**src_neuron).activated_value
-                        };
+        // step through the network backwards and adjust the weights
+        while path.len() > 0 {
+            // get the current node and it's error 
+            let curr_node = self.nodes.get(&path.pop()?).map(to_mut_ref)?;
+            let step = match &self.trace_states {
+                Some(tracer) => curr_node.error * tracer.neuron_derivative(curr_node.innov),
+                None => curr_node.error * curr_node.deactivated_value
+            } * learning_rate;
 
-                        (**src_neuron).error += curr_edge.weight * (**curr_node).error;
-                        curr_edge.update(delta);
-                        path.push(curr_edge.src);
-                    }
-                }
-                
-                // reset the nodes error if it isnt an input node 
-                if (**curr_node).neuron_type != NeuronType::Input {
-                    (**curr_node).bias += learning_rate * (**curr_node).error;
-                    (**curr_node).error = 0.0;
-                }
-            }
+            // iterate through each of the incoming edes to this neuron and adjust it's weight
+            // and add it's error to the errros map
+            for incoming_edge_innov in curr_node.incoming.keys() {
+                let curr_edge = self.edges.get_mut(incoming_edge_innov)?;
 
-            // gather and return the output of the backwards pass
-            let output = self.inputs
-                .iter()
-                .map(|x| {
-                    let neuron = self.nodes.get(x).unwrap();
-                    let error = match &self.trace_states {
-                        Some(tracer) => (**neuron).error * tracer.neuron_activation((**neuron).innov),
-                        None => (**neuron).error * (**neuron).activated_value
+                // if the current edge is active, then it is contributing to the error and we need to adjust it
+                if curr_edge.active {
+                    let src_neuron = self.nodes.get(&curr_edge.src).map(to_mut_ref)?;
+
+                    // add the weight step (gradient) * the currnet value to the weight to adjust the weight
+                    // then update the connection so it knows if it should update the weight, or store the delta
+                    let delta = match &self.trace_states {
+                        Some(tracer) => step * tracer.neuron_activation(src_neuron.innov),
+                        None => step * src_neuron.activated_value
                     };
-                    (**neuron).error = 0.0;
-                    error
-                })
-                .collect();
-            // deduct the backprop index 
-            if let Some(tracer) = &mut self.trace_states {
-                tracer.index -= 1;
+
+                    src_neuron.error += curr_edge.weight * curr_node.error;
+                    curr_edge.update(delta);
+                    path.push(curr_edge.src);
+                }
             }
-            Some(output)
+
+            // reset the nodes error if it isnt an input node 
+            if curr_node.neuron_type != NeuronType::Input {
+                curr_node.bias += learning_rate * curr_node.error;
+                curr_node.error = 0.0;
+            }
         }
+
+        // gather and return the output of the backwards pass
+        let output = self.inputs
+            .iter()
+            .map(|x| {
+                let neuron = self.nodes.get(x).map(to_mut_ref).unwrap();
+                let error = match &self.trace_states {
+                    Some(tracer) => neuron.error * tracer.neuron_activation(neuron.innov),
+                    None => neuron.error * neuron.activated_value
+                };
+                neuron.error = 0.0;
+                error
+            })
+            .collect();
+        // deduct the backprop index 
+        if let Some(tracer) = &mut self.trace_states {
+            tracer.index -= 1;
+        }
+        Some(output)
     }
 
 
@@ -539,7 +532,7 @@ impl Layer for Dense {
         if let Some(tracer) = &mut self.trace_states {
             tracer.reset();
         }
-        unsafe { self.reset_neurons(); }
+        self.reset_neurons();
     }
 
 
@@ -554,7 +547,7 @@ impl Layer for Dense {
     }
 
 
-    
+
     fn as_ref_any(&self) -> &dyn Any
         where Self: Sized + 'static
     {
@@ -582,51 +575,49 @@ impl Genome<Dense, NeatEnvironment> for Dense
 {
     fn crossover(child: &Dense, parent_two: &Dense, env: &Arc<RwLock<NeatEnvironment>>, crossover_rate: f32) -> Option<Dense> {
         let mut new_child = child.clone();
-        unsafe {
-            let set = (*env).read().ok()?;
-            let mut r = rand::thread_rng();
-            if r.gen::<f32>() < crossover_rate {
-                for (innov, edge) in new_child.edges.iter_mut() {
-                    
-                    // if the edge is in both networks, then radnomly assign the weight to the edge
-                    // because we are already looping over the most fit parent, we only need to change the 
-                    // weight to the second parent if nessesary.
-                    if parent_two.edges.contains_key(innov) {
-                        if r.gen::<f32>() < 0.5 {
-                            edge.weight = parent_two.edges.get(innov)?.weight;
-                        }
-                    
-                        // if the edge is deactivated in either network and a random number is less than the 
-                        // reactivate parameter, then reactiveate the edge and insert it back into the network
-                        if (!edge.active || !parent_two.edges.get(innov)?.active) && r.gen::<f32>() < set.reactivate? {
-                            (**new_child.nodes.get(&edge.src)?).outgoing.push(*innov);
-                            (**new_child.nodes.get(&edge.dst)?).incoming.insert(*innov, None);
-                            edge.active = true;
-                        }
+        let set = (*env).read().ok()?;
+        let mut r = rand::thread_rng();
+        if r.gen::<f32>() < crossover_rate {
+            for (innov, edge) in new_child.edges.iter_mut() {
+                // if the edge is in both networks, then radnomly assign the weight to the edge
+                // because we are already looping over the most fit parent, we only need to change the 
+                // weight to the second parent if nessesary.
+                if parent_two.edges.contains_key(innov) {
+                    if r.gen::<f32>() < 0.5 {
+                        edge.weight = parent_two.edges.get(innov)?.weight;
+                    }
+
+                    // if the edge is deactivated in either network and a random number is less than the 
+                    // reactivate parameter, then reactiveate the edge and insert it back into the network
+                    if (!edge.active || !parent_two.edges.get(innov)?.active) && r.gen::<f32>() < set.reactivate? {
+                        new_child.nodes.get(&edge.src).map(to_mut_ref)?
+                          .outgoing.push(*innov);
+                        new_child.nodes.get(&edge.dst).map(to_mut_ref)?
+                          .incoming.insert(*innov, None);
+                        edge.active = true;
                     }
                 }
-            } else {
-                
-                // if a random number is less than the edit_weights parameter, then edit the weights of the network edges
-                // add a possible new node to the network randomly 
-                // attempt to add a new edge to the network, there is a chance this operation will add no edge
-                if r.gen::<f32>() < set.weight_mutate_rate? {
-                    new_child.edit_weights(set.edit_weights?, set.weight_perturb?);
+            }
+        } else {
+            // if a random number is less than the edit_weights parameter, then edit the weights of the network edges
+            // add a possible new node to the network randomly 
+            // attempt to add a new edge to the network, there is a chance this operation will add no edge
+            if r.gen::<f32>() < set.weight_mutate_rate? {
+                new_child.edit_weights(set.edit_weights?, set.weight_perturb?);
+            }
+
+            // if the layer is a dense pool then it can add nodes and connections to the layer as well
+            if new_child.layer_type == LayerType::DensePool {
+                if r.gen::<f32>() < set.new_node_rate? {
+                    let act_func = *set.activation_functions.choose(&mut r)?;
+                    if r.gen::<f32>() < set.recurrent_neuron_rate? {
+                        new_child.add_node(act_func, NeuronDirection::Recurrent);
+                    } else {
+                        new_child.add_node(act_func, NeuronDirection::Forward);
+                    }
                 }
-                
-                // if the layer is a dense pool then it can add nodes and connections to the layer as well
-                if new_child.layer_type == LayerType::DensePool {
-                    if r.gen::<f32>() < set.new_node_rate? {
-                        let act_func = *set.activation_functions.choose(&mut r)?;
-                        if r.gen::<f32>() < set.recurrent_neuron_rate? {
-                            new_child.add_node(act_func, NeuronDirection::Recurrent);
-                        } else {
-                            new_child.add_node(act_func, NeuronDirection::Forward);
-                        }
-                    }
-                    if r.gen::<f32>() < set.new_edge_rate? {
-                        new_child.add_edge();
-                    }
+                if r.gen::<f32>() < set.new_edge_rate? {
+                    new_child.add_edge();
                 }
             }
         }
@@ -662,12 +653,12 @@ impl Clone for Dense {
                 .collect(),
             outputs: self.outputs
                 .iter() 
-                .map(|x| *x)    
+                .map(|x| *x)
                 .collect(),
             nodes: self.nodes
                 .iter()
                 .map(|(key, val)| {
-                    let node = unsafe { (**val).clone() };
+                    let node = to_ref(val).clone();
                     (*key, node.as_mut_ptr())
                 })
                 .collect(),
@@ -683,19 +674,19 @@ impl Clone for Dense {
         }
     }
 }
+
 /// Because the tree is made out of raw mutable pointers, if those pointers
 /// are not dropped, there is a severe memory leak, like possibly gigs of
 /// ram over only a few generations depending on the size of the generation
 /// This drop implementation will recursivley drop all nodes in the tree 
 impl Drop for Dense {
     fn drop(&mut self) { 
-        unsafe {
-            for (_, node) in self.nodes.iter() {
-                drop(Box::from_raw(*node));
-            }
+        for (_, node) in self.nodes.iter() {
+            drop(unsafe { Box::from_raw(*node)});
         }
     }
 }
+
 /// These must be implemneted for the network or any type to be 
 /// used within seperate threads. Because implementing the functions 
 /// themselves is dangerious and unsafe and i'm not smart enough 
@@ -704,6 +695,8 @@ impl Drop for Dense {
 /// program to work
 unsafe impl Send for Dense {}
 unsafe impl Sync for Dense {}
+
+
 /// Implement partialeq for neat because if neat itself is to be used as a problem,
 /// it must be able to compare one to another
 impl PartialEq for Dense {
@@ -738,7 +731,7 @@ impl Serialize for Dense {
         let mut s = serializer.serialize_struct("Dense", 7)?;
         let n = self.nodes
             .iter()
-            .map(|x| (x.0, unsafe { (**x.1).clone_with_values() }) )
+            .map(|x| (x.0, to_ref(x.1).clone_with_values()) )
             .collect::<HashMap<_, _>>();
         s.serialize_field("inputs", &self.inputs)?;
         s.serialize_field("outputs", &self.outputs)?;
@@ -827,9 +820,8 @@ impl<'de> Deserialize<'de> for Dense {
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
                 let activation = seq.next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                    
 
-                let nodes = neurons          
+                let nodes = neurons
                     .iter()
                     .map(|(k, v)| {
                         (k.clone(), v.clone_with_values().as_mut_ptr())

--- a/radiate/src/models/neat/layers/gru.rs
+++ b/radiate/src/models/neat/layers/gru.rs
@@ -2,7 +2,6 @@
 extern crate rand;
 
 use std::fmt;
-use std::mem;
 use std::any::Any;
 use std::sync::{Arc, RwLock};
 use super::{
@@ -195,18 +194,10 @@ impl Genome<GRU, NeatEnvironment> for GRU
     }
 }
 
-/// These must be implemneted for the network or any type to be 
-/// used within seperate threads. Because implementing the functions 
-/// themselves is dangerious and unsafe and i'm not smart enough 
-/// to do that from scratch, these "implmenetaions" will get rid 
-/// of the error and realistically they don't need to be implemneted for the
-/// program to work
 /// implement display for the GRU layer of the network
 impl fmt::Display for GRU {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unsafe {
-            let address: u64 = mem::transmute(self);
-            write!(f, "GRU=[{}]", address)
-        }
+        write!(f, "GRU=[input={}, memory={}, output={}]",
+          self.input_size, self.memory_size, self.output_size)
     }
 }

--- a/radiate/src/models/neat/layers/gru.rs
+++ b/radiate/src/models/neat/layers/gru.rs
@@ -92,7 +92,7 @@ impl Layer for GRU {
     }
 
 
-    fn backward(&mut self, errors: &Vec<f32>, learning_rate: f32) -> Option<Vec<f32>> {
+    fn backward(&mut self, _errors: &Vec<f32>, _learning_rate: f32) -> Option<Vec<f32>> {
         panic!("Backprop for GRU is not implemented yet");
         // let output_error = self.o_gate.backward(&errors, learning_rate)?;
         // // let delta_mem = self.current_memory
@@ -201,8 +201,6 @@ impl Genome<GRU, NeatEnvironment> for GRU
 /// to do that from scratch, these "implmenetaions" will get rid 
 /// of the error and realistically they don't need to be implemneted for the
 /// program to work
-unsafe impl Send for GRU {}
-unsafe impl Sync for GRU {}
 /// implement display for the GRU layer of the network
 impl fmt::Display for GRU {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/radiate/src/models/neat/layers/layer.rs
+++ b/radiate/src/models/neat/layers/layer.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 /// comes in - allowing the Box<dyn Layer> to be cloned without knowing which type it 
 /// really is under the hood. Any allows for the underlying object to be downcast to a concrete type
 #[typetag::serde(tag = "type")]
-pub trait Layer: LayerClone + Any + Debug {
+pub trait Layer: LayerClone + Any + Debug + Send + Sync {
     
     /// propagate an input vec through this layer. This is done differently 
     /// depending on the type of layer, just the same as backpropagation is.

--- a/radiate/src/models/neat/layers/lstm.rs
+++ b/radiate/src/models/neat/layers/lstm.rs
@@ -445,15 +445,10 @@ impl Genome<LSTM, NeatEnvironment> for LSTM
     }
 }
 
-/// These must be implemneted for the network or any type to be 
-/// used within seperate threads. Because implementing the functions 
-/// themselves is dangerious and unsafe and i'm not smart enough 
-/// to do that from scratch, these "implmenetaions" will get rid 
-/// of the error and realistically they don't need to be implemneted for the
-/// program to work
 /// implement display for the LSTM layer of the network
 impl fmt::Display for LSTM {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "LSTM=[{}]", "LSTM")
+        write!(f, "LSTM=[input={}, memory={}, output={}]",
+          self.input_size, self.memory_size, self.output_size)
     }
 }

--- a/radiate/src/models/neat/layers/lstm.rs
+++ b/radiate/src/models/neat/layers/lstm.rs
@@ -451,8 +451,6 @@ impl Genome<LSTM, NeatEnvironment> for LSTM
 /// to do that from scratch, these "implmenetaions" will get rid 
 /// of the error and realistically they don't need to be implemneted for the
 /// program to work
-unsafe impl Send for LSTM {}
-unsafe impl Sync for LSTM {}
 /// implement display for the LSTM layer of the network
 impl fmt::Display for LSTM {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/radiate/src/models/neat/neat.rs
+++ b/radiate/src/models/neat/neat.rs
@@ -284,14 +284,7 @@ impl Clone for Neat {
         }
     }
 }
-/// These must be implemneted for the network or any type to be 
-/// used within seperate threads. Because implementing the functions 
-/// themselves is dangerious and unsafe and i'm not smart enough 
-/// to do that from scratch, these "implmenetaions" will get rid 
-/// of the error and realistically they don't need to be implemneted for the
-/// program to work
-unsafe impl Send for Neat {}
-unsafe impl Sync for Neat {}
+
 /// Implement partialeq for neat because if neat itself is to be used as a problem,
 /// it must be able to compare one to another
 impl PartialEq for Neat {

--- a/radiate/src/models/neat/neatenv.rs
+++ b/radiate/src/models/neat/neatenv.rs
@@ -110,10 +110,6 @@ impl NeatEnvironment {
 }
 
 
-unsafe impl Send for NeatEnvironment {}
-unsafe impl Sync for NeatEnvironment {}
-
-
 impl Default for NeatEnvironment {
     fn default() -> Self {
         Self::new()

--- a/radiate_matrix_tree/src/lib.rs
+++ b/radiate_matrix_tree/src/lib.rs
@@ -1,17 +1,20 @@
 
 pub mod prelude;
+pub mod tree;
 pub mod matrix_tree;
 
-pub use matrix_tree::{
-    evtree::Evtree,
-    evenv::TreeEnvionment,
+pub use tree::{
     iterators::{
         InOrderIterator,
         LevelOrderIterator,
         IterMut
     },
+};
+
+pub use matrix_tree::{
+    evtree::Evtree,
+    evenv::TreeEnvionment,
     network::NeuralNetwork,
-    node::Node
 };
 
 /// get a default environment settings for evtree, these are very basic and 

--- a/radiate_matrix_tree/src/matrix_tree/evenv.rs
+++ b/radiate_matrix_tree/src/matrix_tree/evenv.rs
@@ -209,10 +209,6 @@ impl TreeEnvionment {
 }
 
 
-unsafe impl Send for TreeEnvionment {}
-unsafe impl Sync for TreeEnvionment {}
-
-
 impl Default for TreeEnvionment {
     fn default() -> Self {
         Self::new()

--- a/radiate_matrix_tree/src/matrix_tree/evtree.rs
+++ b/radiate_matrix_tree/src/matrix_tree/evtree.rs
@@ -346,11 +346,13 @@ impl Evtree {
 /// implemented a display function for the Tree just for easier debugging 
 impl fmt::Debug for Evtree {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        /*
         unsafe {
             // let address: u64 = mem::transmute(self);
             // let root: u64 = if self.root != ptr::null_mut() { mem::transmute(&*self.root) } else { 0x64 };
-            write!(f, "Tree=[{}]", self.size)
         }
+        */
+        write!(f, "Tree=[{}]", self.size)
     }
 }
 /// Return a new copy of the tree, calling deep copy from the root node and copying over

--- a/radiate_matrix_tree/src/matrix_tree/evtree.rs
+++ b/radiate_matrix_tree/src/matrix_tree/evtree.rs
@@ -3,24 +3,48 @@ extern crate rand;
 extern crate simple_matrix;
 extern crate radiate;
 
-use std::fmt;
-use std::marker::Sync;
 use std::sync::{Arc, RwLock};
-use rand::seq::SliceRandom;
 use rand::rngs::ThreadRng;
 use rand::Rng;
 use simple_matrix::Matrix;
+
+use crate::tree::*;
 use super::{
-    iterators,
-    node::{Node, Link},
     network::NeuralNetwork, 
     evenv::TreeEnvionment
 };
 
 use radiate::engine::genome::Genome;
 
+/// a Node struct to represent a bidirectional binary tree
+/// holding pointers to the parent and two children, the left and right child
+/// The node also holds an input size which is the expected size of the input vector 
+/// for the neural network held within the node. The output represetns the postion of the 
+/// node, meaning that if it is a leaf, it will return the output from a get output function
+#[derive(Debug, Clone, PartialEq)]
+pub struct NetNode {
+    pub neural_network: NeuralNetwork,
+    pub input_size: i32,
+    pub output: u8
+}
 
-
+/// implement the node
+impl NetNode {
+    /// create a new node with a given input size and a list of possible output options 
+    /// 
+    /// From the list of output_options the node will choose an output,
+    /// from the input_size the node will create a randomly generated 
+    /// neural network.
+    pub fn new(input_size: i32, output_options: &Vec<i32>) -> Self {
+        let mut r = rand::thread_rng();
+        let output = output_options[r.gen_range(0, output_options.len())] as u8;
+        Self {
+            neural_network: NeuralNetwork::new(input_size).fill_random(),
+            input_size,
+            output
+        }
+    }
+}
 
 /// A tree struct to encapsulate a bidirectional binary tree.AsMut
 /// 
@@ -30,252 +54,10 @@ use radiate::engine::genome::Genome;
 /// This struct holds the root of the tree. The tree also contains a size which represents the number of nodes in the tree,
 /// an input size which is the size of the input vector (1D), and is used to generate nodes alone with the 
 /// output options which is an owned vec of i32s represnting different outputs of the classification.
-#[derive(PartialEq)]
-pub struct Evtree {
-    root: Link,
-    size: i32,
-}
-
-
+pub type Evtree = Tree<NetNode>;
 
 /// implement the tree
 impl Evtree {
-
-    /// Create a new default Tree given an input size and a vec of possible outputs 
-    /// 
-    /// Returns the newly created Tree with no root node, a size of 
-    /// 0 and an owned input_size and output_options.
-    pub fn new() -> Self {
-        Evtree {
-            root: Link::None,
-            size: 0,
-        }
-    }
-
-
-    fn root_mut_opt(&mut self) -> Option<&mut Node> {
-        self.root.as_mut().map(|n| n.as_mut())
-    }
-
-    fn root_opt(&self) -> Option<&Node> {
-        self.root.as_ref().map(|n| n.as_ref())
-    }
-
-    fn set_root(&mut self, root: Link) {
-        self.drop_root();
-        self.root = root;
-    }
-
-    fn drop_root(&mut self) {
-        self.root = Link::None;
-    }
-
-    /// return an in order iterator which 
-    /// allows for the nodes in the tree to be
-    /// mutatued while iterating
-    pub fn iter_mut(&mut self) -> iterators::IterMut {
-        iterators::IterMut::new(self.root_mut_opt())
-    }
-
-
-
-    /// Return a level order iterator
-    /// Iterators over the tree from top to bottom, 
-    /// going from parent, to it's left child then it's right child.
-    /// Each node that the iterator yields is a reference to a Node struct
-    pub fn level_order_iter(&self) -> iterators::LevelOrderIterator {
-        iterators::LevelOrderIterator::new(self.root_opt())
-    }
-
-
-
-    /// Return an in order iterator
-    /// Iterates over the tree in order, from left to right
-    /// with the root in the middle (assuming balanced)
-    /// Each node that the iterator yields is a reference to a Node struct
-    pub fn in_order_iter(&self) -> iterators::InOrderIterator {
-        iterators::InOrderIterator::new(self.root_opt())
-    }
-
-
-
-    /// the len of the tree is it's size, the numbr of nodes
-    pub fn len(&self) -> &i32 {
-        &self.size
-    }
-
-
-    /// Update size from root node.
-    pub fn update_size(&mut self) {
-        self.size = match self.root_opt() {
-            Some(root) => root.size(),
-            None => 0,
-        };
-    }
-
-
-    /// return the height of the tree from the root 
-    #[inline]    
-    pub fn height(&self) -> i32 {
-        match self.root_opt() {
-            Some(root) => root.height(),
-            None => 0,
-        }
-    }
-
-
-
-    /// Get a node from the tree at a given index and return an option with
-    /// either the node in it, or none. 
-    /// 
-    /// Panic! if the index is greater than the size of the tree.
-    #[inline]    
-    pub fn get(&mut self, index: usize) -> &mut Node {
-        let mut temp: Option<&mut Node> = None;
-        for (i, node) in self.iter_mut().enumerate() {
-            if i == index {
-                temp = Some(node);
-                break;
-            }
-        }
-        temp.unwrap_or_else(|| panic!("Index not found in tree."))
-    }
-
-
-
-    /// Get the index of a given node in the tree
-    #[inline]    
-    pub fn index_of(&self, node: &Node) -> usize {
-        let mut temp: Option<usize> = None;
-        for (index, curr) in self.in_order_iter().enumerate() {
-            if curr == node {
-                temp = Some(index);
-                break;
-            }
-        }
-        temp.unwrap_or_else(|| panic!("Node index not found."))
-    }
-
-
-
-    /// Insert a node to the tree randomly and increase the size by 1 each time.
-    pub fn insert_random(&mut self, input_size: i32, outputs: &Vec<i32>) {
-        match self.root_mut_opt() {
-            Some(root) => {
-                root.insert_random(input_size, outputs);
-            },
-            None => {
-                self.set_root(Some(Node::new(input_size, outputs)));
-            },
-        }
-        self.size += 1;
-    }
-
-
-
-    /// display the tree by calling the recursive display method within the node 
-    /// implementation at level 0. If no root node, panic!
-    pub fn display(&self) {
-        match &self.root {
-            None => panic!("The no root node"),
-            Some(root) => root.display(0),
-        }
-    }
-
-
-
-    /// Balance the tree by thin copying each node then calling a private
-    /// recursive function to build the tree structure.
-    /// 
-    /// Return an option in order to use '?' instead of 'unwrap()' in the 
-    /// function body.
-    pub fn balance(&mut self) {
-        let mut node_bag = self.in_order_iter()
-            .map(|x: &Node| Some(x.copy()))
-            .collect::<Vec<_>>();
-        self.set_root(self.make_tree(&mut node_bag[..]));
-    }
-
-
-    /// Recursively build a balanced binary tree by splitting the slice into left/right
-    /// sides at the middle node.
-    /// Return a `Link` to the middle node to be set as the child of a parent node or as the root node.
-    #[inline]    
-    fn make_tree(&self, bag: &mut [Link]) -> Link {
-        let midpoint = bag.len() / 2;
-        // split at midpoint
-        let (left, right) = bag.split_at_mut(midpoint);
-        // 'right' side has the node we need.
-        if let Some((node, right)) = right.split_first_mut() {
-            // take the node from the bag.  This replaces it with `None`
-            let mut curr_node = node.take().unwrap();
-            // make sure it doesn't have a parent.
-            curr_node.set_left_child(self.make_tree(left));
-            curr_node.set_right_child(self.make_tree(right));
-            Some(curr_node)
-        } else {
-            // bag is empty
-            return None;
-        }
-    }
-
-
-
-    /// get a vec of node references in a bised sense where
-    /// nodes at a lower level are favored 
-    #[inline]    
-    pub fn get_biased_level<'a>(&'a self) -> Vec<&'a Node> {
-        let mut r = rand::thread_rng();
-        let index = r.gen_range(0, self.len()) as usize;
-        let levels = self.level_order_iter()
-            .map(|x: &Node| self.height() - x.height())
-            .collect::<Vec<_>>();
-
-        // return a vec where the depth of a node is equal to 
-        // the biased level chosen. Order does not matter
-        // because there will be more numbers in the levels vec with 
-        // a lower depth inherintly due to tree structures
-        self.in_order_iter()
-            .filter(|x| x.depth() == levels[index])
-            .collect::<Vec<_>>()
-    }
-
-
-
-    /// Get a biased random node from the tree by gathering a biased random level
-    /// towards the bottom of the tree, then returning a reference to the chosen node
-    pub fn get_biased_random_node<'a>(&'a self) -> &'a Node {
-        let mut nodes = self.get_biased_level();
-        let index = rand::thread_rng().gen_range(0, nodes.len());
-        nodes.remove(index)
-    }
-
-
-
-    /// take in an index of the tree to swap with the pointer of another subtree
-    /// by simply switching the pointers of the node at swap_index and the other_node pointer
-    fn replace(&mut self, swap_index: usize, mut other_node: Box<Node>) {
-        let swap_node = self.get(swap_index);
-        match swap_node.parent_mut_opt() {
-            Some(parent) => {
-                if parent.check_left_child(swap_node) {
-                    parent.set_left_child(Some(other_node));
-                } else if parent.check_right_child(swap_node) {
-                    parent.set_right_child(Some(other_node));
-                } else {
-                    unreachable!("Invalid tree structure.  The node is not a child of it's parent.");
-                }
-            },
-            None => {
-                other_node.remove_from_parent();
-                self.set_root(Some(other_node));
-            }
-        }
-        self.update_size();
-    }
-
-
-
     /// Gut a random node from the tree. Get a random index from the tree
     /// then give that node a new neural network.
     pub fn gut_random_node(&mut self, r: &mut ThreadRng) {
@@ -283,21 +65,6 @@ impl Evtree {
         let temp_node = self.get(index);
         temp_node.neural_network = NeuralNetwork::new(temp_node.input_size);
     }
-
-
-
-    /// Shuffel the tree by gathering a list of the nodes then shuffling the list
-    /// and then balancing the tree again from that list
-    #[inline]    
-    pub fn shuffle_tree(&mut self, r: &mut ThreadRng) {
-        let mut node_list = self.in_order_iter()
-            .map(|x: &Node| Some(x.copy()))
-            .collect::<Vec<_>>();
-        node_list.shuffle(r);
-        self.set_root(self.make_tree(&mut node_list[..]));
-    }
-
-
 
     /// Go through each of the nodes in the tree and randomly mutate 
     /// the weights and biases within the network 
@@ -307,8 +74,6 @@ impl Evtree {
             node.neural_network.edit_weights(weight_mutate, weight_transform, layer_mutate);
         }
     }
-
-
 
     /// Compute the asymmetry for a single tree 
     /// by adding the height times the neural network 
@@ -322,8 +87,6 @@ impl Evtree {
         }
         total.sin()
     }
-
-
 
     pub fn propagate(&self, inputs: Matrix<f32>) -> u8 {
         let mut curr_node = self.root_opt()
@@ -355,66 +118,7 @@ impl Evtree {
             }
         }
     }
-
-
 }
-
-
-
-
-
-/// implemented a display function for the Tree just for easier debugging 
-impl fmt::Debug for Evtree {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Tree=[{}]", self.size)
-    }
-}
-/// Return a new copy of the tree, calling deep copy from the root node and copying over
-/// the size, input size, and output options in the most effecient way.
-/// TODO: this looks like messy.. is there a way to clean up?
-impl Clone for Evtree {
-    #[inline]
-    fn clone(&self) -> Evtree {
-        // Deep copy root node if any.
-        let root = self.root_opt().map(|n| n.deepcopy());
-        Evtree {
-            root,
-            size: self.size,
-        }
-    }
-}
-/// Because the tree is made out of raw mutable pointers, if those pointers
-/// are not dropped, there is a severe memory leak, like possibly gigs of
-/// ram over only a few generations depending on the size of the generation
-/// This drop implementation will recursivley drop all nodes in the tree 
-impl Drop for Evtree {
-    fn drop(&mut self) { 
-        self.drop_root();
-    }
-}
-/// These must be implemneted for the tree or any type to be 
-/// used within seperate threads. Because implementing the functions 
-/// themselves is dangerious and unsafe and i'm not smart enough 
-/// to do that from scratch, these "implmenetaions" will get rid 
-/// of the error and realistically they don't need to be implemneted for the
-/// program to work
-unsafe impl Send for Evtree {}
-unsafe impl Sync for Evtree {}
-
-
-/// implement a function for getting a base default Evtree which is completetly empty
-/// There are multiple places within the struct implementation which will panic! if 
-/// this default Evtree is passed through it.
-impl Default for Evtree {
-    fn default() -> Evtree {
-        Evtree {
-            root: Link::None,
-            size: 0
-        }
-    }
-}
-
-
 
 impl Genome<Evtree, TreeEnvionment> for Evtree {
     /// one should be the more fit Evtree and two should be the less fit Evtree.
@@ -448,7 +152,7 @@ impl Genome<Evtree, TreeEnvionment> for Evtree {
                 result.edit_random_node_networks(set.weight_mutate_rate?, set.weight_transform_rate?, set.layer_mutate_rate?);
             }
             if r.gen::<f32>() < set.node_add_rate? {
-                result.insert_random(set.input_size?, set.get_outputs());
+                result.insert_random(NetNode::new(set.input_size?, set.get_outputs()));
             }
             if r.gen::<f32>() < set.shuffle_rate? {
                 result.shuffle_tree(&mut r);
@@ -469,14 +173,11 @@ impl Genome<Evtree, TreeEnvionment> for Evtree {
     /// Get the base tree type and return a randomly generated base tree 
     /// created through the tree settings given to it at its new() call
     fn base(settings: &mut TreeEnvionment) -> Evtree {
-        let mut result = Evtree::new();
-        let mut nodes = (0..(2 * settings.get_max_height()) - 1)
-            .map(|_| Some(Node::new(settings.get_input_size(), settings.get_outputs())))
+        let nodes = (0..(2 * settings.get_max_height()) - 1)
+            .map(|_| Some(NetNode::new(settings.get_input_size(), settings.get_outputs())))
             .collect::<Vec<_>>();
 
-        result.size = nodes.len() as i32;
-        result.set_root(result.make_tree(&mut nodes[..]));
-        result
+        Evtree::from_slice(nodes)
     }
 
 
@@ -489,5 +190,3 @@ impl Genome<Evtree, TreeEnvionment> for Evtree {
         (one.asymmetry() - two.asymmetry()).abs()
     }
 }
-
-

--- a/radiate_matrix_tree/src/matrix_tree/evtree.rs
+++ b/radiate_matrix_tree/src/matrix_tree/evtree.rs
@@ -173,11 +173,11 @@ impl Genome<Evtree, TreeEnvionment> for Evtree {
     /// Get the base tree type and return a randomly generated base tree 
     /// created through the tree settings given to it at its new() call
     fn base(settings: &mut TreeEnvionment) -> Evtree {
-        let nodes = (0..(2 * settings.get_max_height()) - 1)
+        let mut nodes = (0..(2 * settings.get_max_height()) - 1)
             .map(|_| Some(NetNode::new(settings.get_input_size(), settings.get_outputs())))
             .collect::<Vec<_>>();
 
-        Evtree::from_slice(nodes)
+        Evtree::from_slice(&mut nodes[..])
     }
 
 

--- a/radiate_matrix_tree/src/matrix_tree/evtree.rs
+++ b/radiate_matrix_tree/src/matrix_tree/evtree.rs
@@ -62,7 +62,7 @@ impl Evtree {
     /// then give that node a new neural network.
     pub fn gut_random_node(&mut self, r: &mut ThreadRng) {
         let index = r.gen_range(0, self.len()) as usize;
-        let temp_node = self.get(index);
+        let temp_node = self.get_mut(index).unwrap();
         temp_node.neural_network = NeuralNetwork::new(temp_node.input_size);
     }
 

--- a/radiate_matrix_tree/src/matrix_tree/evtree.rs
+++ b/radiate_matrix_tree/src/matrix_tree/evtree.rs
@@ -180,7 +180,7 @@ impl Evtree {
                 root.insert_random(input_size, outputs);
             },
             None => {
-                self.root = Node::new(input_size, outputs).as_mut_ptr();
+                self.set_root(Node::new(input_size, outputs).as_mut_ptr());
             },
         }
         self.size += 1;

--- a/radiate_matrix_tree/src/matrix_tree/evtree.rs
+++ b/radiate_matrix_tree/src/matrix_tree/evtree.rs
@@ -78,24 +78,11 @@ impl Evtree {
     }
 
     fn drop_root(&mut self) {
-        if self.root == ptr::null_mut() {
-            return;
+        if self.root != ptr::null_mut() {
+            let root = unsafe { Box::from_raw(self.root) };
+            self.root = ptr::null_mut();
+            drop(root)
         }
-        unsafe {
-            let mut stack = Vec::with_capacity(*self.len() as usize);
-            stack.push(self.root);
-            while stack.len() > 0 {
-                let curr_node = stack.pop().unwrap();
-                if (&*curr_node).has_left_child() {
-                    stack.push((&*curr_node).left_child);
-                }
-                if (&*curr_node).has_right_child() {
-                    stack.push((&*curr_node).right_child);
-                }
-                drop(Box::from_raw(curr_node));
-            }
-        }
-        self.root = ptr::null_mut();
     }
 
     /// return an in order iterator which 

--- a/radiate_matrix_tree/src/matrix_tree/evtree.rs
+++ b/radiate_matrix_tree/src/matrix_tree/evtree.rs
@@ -89,11 +89,7 @@ impl Evtree {
     /// allows for the nodes in the tree to be
     /// mutatued while iterating
     pub fn iter_mut(&mut self) -> iterators::IterMut {
-        let mut stack = Vec::new();
-        if let Some(root) = self.root_mut_opt() {
-            stack.push(root);
-        }
-        iterators::IterMut { stack }
+        iterators::IterMut::new(self.root_mut_opt())
     }
 
 
@@ -103,11 +99,7 @@ impl Evtree {
     /// going from parent, to it's left child then it's right child.
     /// Each node that the iterator yields is a reference to a Node struct
     pub fn level_order_iter(&self) -> iterators::LevelOrderIterator {
-        let mut stack = Vec::new();
-        if let Some(root) = self.root_opt() {
-            stack.push(root);
-        }
-        iterators::LevelOrderIterator { stack }
+        iterators::LevelOrderIterator::new(self.root_opt())
     }
 
 
@@ -117,11 +109,7 @@ impl Evtree {
     /// with the root in the middle (assuming balanced)
     /// Each node that the iterator yields is a reference to a Node struct
     pub fn in_order_iter(&self) -> iterators::InOrderIterator {
-        let mut stack = Vec::new();
-        if let Some(root) = self.root_opt() {
-            stack.push(root);
-        }
-        iterators::InOrderIterator { stack }
+        iterators::InOrderIterator::new(self.root_opt())
     }
 
 

--- a/radiate_matrix_tree/src/matrix_tree/mod.rs
+++ b/radiate_matrix_tree/src/matrix_tree/mod.rs
@@ -1,5 +1,3 @@
 pub mod evtree;
-pub mod node;
 pub mod network;
 pub mod evenv;
-pub mod iterators;

--- a/radiate_matrix_tree/src/matrix_tree/node.rs
+++ b/radiate_matrix_tree/src/matrix_tree/node.rs
@@ -1,9 +1,7 @@
 use rand::Rng;
 use std::ptr;
-use std::mem;
 use std::cmp::max;
 use std::fmt;
-use std::marker::Sync;
 
 use super::network::NeuralNetwork;
 
@@ -255,12 +253,6 @@ impl Drop for Node {
 
 
 
-unsafe impl Send for Node {}
-
-unsafe impl Sync for Node {}
-
-
-
 /// implemented a display function for the node to display a simple representation of the node
 impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -275,12 +267,14 @@ impl fmt::Display for Node {
 /// make it easier to trace through a tree when a tree is displayed
 impl fmt::Debug for Node {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        /*
         unsafe {
             // let address: u64 = mem::transmute(self);
             // let left: u64 = if self.has_left_child() { mem::transmute(&*self.left_child) } else { 0x64 };
             // let right: u64 = if self.has_right_child() { mem::transmute(&*self.right_child) } else { 0x64 };
-            write!(f, "Node=[{}]", self.output)
         }
+        */
+        write!(f, "Node=[{}]", self.output)
     }
 }
 

--- a/radiate_matrix_tree/src/matrix_tree/node.rs
+++ b/radiate_matrix_tree/src/matrix_tree/node.rs
@@ -209,7 +209,8 @@ impl Node {
     /// The returned node is owned by the caller
     pub fn take_left_child(&mut self) -> Option<Box<Node>> {
         if self.has_left_child() {
-            let child = unsafe { Box::from_raw(self.left_child) };
+            let mut child = unsafe { Box::from_raw(self.left_child) };
+            child.parent = ptr::null_mut();
             self.left_child = ptr::null_mut();
             Some(child)
         } else {
@@ -221,7 +222,8 @@ impl Node {
     /// The returned node is owned by the caller
     pub fn take_right_child(&mut self) -> Option<Box<Node>> {
         if self.has_right_child() {
-            let child = unsafe { Box::from_raw(self.right_child) };
+            let mut child = unsafe { Box::from_raw(self.right_child) };
+            child.parent = ptr::null_mut();
             self.right_child = ptr::null_mut();
             Some(child)
         } else {
@@ -379,7 +381,10 @@ impl Node {
 /// subree. These are made out of raw pointers so they need to be 
 /// dropped manually
 impl Drop for Node {
-    fn drop(&mut self) {  }
+    fn drop(&mut self) {
+        self.take_left_child();
+        self.take_right_child();
+    }
 }
 
 

--- a/radiate_matrix_tree/src/tree/iterators.rs
+++ b/radiate_matrix_tree/src/tree/iterators.rs
@@ -5,31 +5,31 @@ use super::node::Node;
 
 /// Level order iterator struct to keep track of the current position of
 /// the iterator while iterating over the tree
-pub struct LevelOrderIterator<'a> {
-    pub stack: Vec<&'a Node>
+pub struct LevelOrderIterator<'a, T: Clone> {
+    pub stack: Vec<&'a Node<T>>
 }
 
 
 
 /// In order iterator for the tree. Keeps a vec to remember the current position 
 /// of the tree during iteration.
-pub struct InOrderIterator<'a> {
-    pub next: Option<&'a Node>,
+pub struct InOrderIterator<'a, T: Clone> {
+    pub next: Option<&'a Node<T>>,
 }
 
 
 
 /// Implement an in order iterator which allows for mutability of the 
 /// nodes inside the iterator
-pub struct IterMut<'a> {
-    pub stack: Vec<Option<*mut Node>>,
-    phantom: std::marker::PhantomData<&'a Node>,
+pub struct IterMut<'a, T: Clone> {
+    pub stack: Vec<Option<*mut Node<T>>>,
+    phantom: std::marker::PhantomData<&'a Node<T>>,
 }
 
 
 
-impl<'a> LevelOrderIterator<'a> {
-    pub fn new(root: Option<&'a Node>) -> Self {
+impl<'a, T: Clone> LevelOrderIterator<'a, T> {
+    pub fn new(root: Option<&'a Node<T>>) -> Self {
         let mut stack = Vec::new();
         if let Some(root) = root {
             stack.push(root);
@@ -44,8 +44,8 @@ impl<'a> LevelOrderIterator<'a> {
 /// Implement the level order iterator, all iterators in Rust call the next function
 /// and because it takes a mutable reference to self, the node which is yielded by 
 /// the iterator can be mutated during iteration, but will not free memory by being consumed.
-impl<'a> Iterator for LevelOrderIterator<'a> {
-    type Item = &'a Node;
+impl<'a, T: Clone> Iterator for LevelOrderIterator<'a, T> {
+    type Item = &'a Node<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let curr_node = self.stack.pop()?;
@@ -61,7 +61,7 @@ impl<'a> Iterator for LevelOrderIterator<'a> {
 
 
 /// Find the left most node in the tree.
-fn left_most<'a>(node: Option<&'a Node>) -> Option<&'a Node> {
+fn left_most<'a, T: Clone>(node: Option<&'a Node<T>>) -> Option<&'a Node<T>> {
     // The first node is the left most node in the tree.
     match node {
         Some(mut next) => {
@@ -76,8 +76,8 @@ fn left_most<'a>(node: Option<&'a Node>) -> Option<&'a Node> {
 }
 
 
-impl<'a> InOrderIterator<'a> {
-    pub fn new(root: Option<&'a Node>) -> Self {
+impl<'a, T: Clone> InOrderIterator<'a, T> {
+    pub fn new(root: Option<&'a Node<T>>) -> Self {
         // The first node is the left most node in the tree.
         Self {
             next: left_most(root),
@@ -89,8 +89,8 @@ impl<'a> InOrderIterator<'a> {
 /// Implement the in order iterator. Will call the next function and fall down the 
 /// left side of the tree till there is no left child, that is the yielded node.
 /// The add the right child and continue iterating.
-impl<'a> Iterator for InOrderIterator<'a> {
-    type Item = &'a Node;
+impl<'a, T: Clone> Iterator for InOrderIterator<'a, T> {
+    type Item = &'a Node<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Save the current next node to be returned.
@@ -135,11 +135,11 @@ impl<'a> Iterator for InOrderIterator<'a> {
 
 
 /// TODO: Try using non-stack algorithm.
-impl<'a> IterMut<'a> {
-    pub fn new(root: Option<&'a mut Node>) -> Self {
+impl<'a, T: Clone> IterMut<'a, T> {
+    pub fn new(root: Option<&'a mut Node<T>>) -> Self {
         let mut stack = Vec::new();
         //if let Some(root) = root {
-            stack.push(root.map(|n| n as *mut Node));
+            stack.push(root.map(|n| n as *mut Node<T>));
         //}
         Self {
             stack,
@@ -152,8 +152,8 @@ impl<'a> IterMut<'a> {
 /// which allows for internal mutability of the 
 /// nodes - same implementation as in_order_iter()
 /// but allows for mutation
-impl<'a> Iterator for IterMut<'a> {
-    type Item = &'a mut Node;
+impl<'a, T: Clone> Iterator for IterMut<'a, T> {
+    type Item = &'a mut Node<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(mut curr_node) = self.stack.pop() {
@@ -169,5 +169,3 @@ impl<'a> Iterator for IterMut<'a> {
         })
     }
 }
-
-

--- a/radiate_matrix_tree/src/tree/mod.rs
+++ b/radiate_matrix_tree/src/tree/mod.rs
@@ -230,21 +230,22 @@ impl<T: Clone> Tree<T> {
     pub(crate) fn replace(&mut self, swap_index: usize, mut other_node: Box<Node<T>>) {
         let swap_node = self.get_node_mut(swap_index)
           .expect("Index not found in tree.");
-        match swap_node.parent_mut_opt() {
-            Some(parent) => {
-                if parent.check_left_child(swap_node) {
+        match swap_node.is_left_child() {
+            Some(true) => {
+                if let Some(parent) = swap_node.parent_mut_opt() {
                     parent.set_left_child(Some(other_node));
-                } else if parent.check_right_child(swap_node) {
+                }
+            },
+            Some(false) => {
+                if let Some(parent) = swap_node.parent_mut_opt() {
                     parent.set_right_child(Some(other_node));
-                } else {
-                    unreachable!("Invalid tree structure.  The node is not a child of it's parent.");
                 }
             },
             None => {
                 other_node.remove_from_parent();
                 self.set_root(Some(other_node));
             }
-        }
+        };
         self.update_size();
     }
 

--- a/radiate_matrix_tree/src/tree/mod.rs
+++ b/radiate_matrix_tree/src/tree/mod.rs
@@ -37,10 +37,10 @@ impl<T: Clone> Tree<T> {
     }
 
     /// build tree from node slice
-    pub fn from_slice(mut nodes: Vec<Option<T>>) -> Self {
+    pub fn from_slice(nodes: &mut [Option<T>]) -> Self {
         let mut tree = Self::new();
         tree.size = nodes.len() as i32;
-        tree.set_root(tree.make_tree(&mut nodes[..]));
+        tree.set_root(tree.make_tree(nodes));
         tree
     }
 
@@ -85,8 +85,8 @@ impl<T: Clone> Tree<T> {
     }
 
     /// the len of the tree is it's size, the numbr of nodes
-    pub fn len(&self) -> &i32 {
-        &self.size
+    pub fn len(&self) -> usize {
+        self.size as usize
     }
 
     /// Update size from root node.
@@ -197,9 +197,10 @@ impl<T: Clone> Tree<T> {
     #[inline]    
     pub fn get_biased_level<'a>(&'a self) -> Vec<&'a Node<T>> {
         let mut r = rand::thread_rng();
+        let height = self.height();
         let index = r.gen_range(0, self.len()) as usize;
         let levels = self.level_order_iter()
-            .map(|x: &Node<T>| self.height() - x.height())
+            .map(|x: &Node<T>| height - x.height())
             .collect::<Vec<_>>();
 
         // return a vec where the depth of a node is equal to 

--- a/radiate_matrix_tree/src/tree/mod.rs
+++ b/radiate_matrix_tree/src/tree/mod.rs
@@ -106,20 +106,25 @@ impl<T: Clone> Tree<T> {
         }
     }
 
+    /// Get a node's element from the tree at a given index and return an option with
+    /// either the node's element in it, or none.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.in_order_iter().nth(index).map(|n| n.get())
+    }
+
+    /// Get a node's element from the tree at a given index and return an option with
+    /// either the node's element in it, or none.
+    #[inline]
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+        self.get_node_mut(index).map(|n| n.get_mut())
+    }
+
     /// Get a node from the tree at a given index and return an option with
-    /// either the node in it, or none. 
-    /// 
-    /// Panic! if the index is greater than the size of the tree.
-    #[inline]    
-    pub fn get(&mut self, index: usize) -> &mut Node<T> {
-        let mut temp: Option<&mut Node<T>> = None;
-        for (i, node) in self.iter_mut().enumerate() {
-            if i == index {
-                temp = Some(node);
-                break;
-            }
-        }
-        temp.unwrap_or_else(|| panic!("Index not found in tree."))
+    /// either the node in it, or none.
+    #[inline]
+    pub fn get_node_mut(&mut self, index: usize) -> Option<&mut Node<T>> {
+        self.iter_mut().nth(index)
     }
 
     /// Get the index of a given node in the tree
@@ -223,7 +228,8 @@ impl<T: Clone> Tree<T> {
     /// take in an index of the tree to swap with the pointer of another subtree
     /// by simply switching the pointers of the node at swap_index and the other_node pointer
     pub(crate) fn replace(&mut self, swap_index: usize, mut other_node: Box<Node<T>>) {
-        let swap_node = self.get(swap_index);
+        let swap_node = self.get_node_mut(swap_index)
+          .expect("Index not found in tree.");
         match swap_node.parent_mut_opt() {
             Some(parent) => {
                 if parent.check_left_child(swap_node) {

--- a/radiate_matrix_tree/src/tree/mod.rs
+++ b/radiate_matrix_tree/src/tree/mod.rs
@@ -1,0 +1,306 @@
+use std::fmt;
+use std::marker::Sync;
+use rand::seq::SliceRandom;
+use rand::rngs::ThreadRng;
+use rand::Rng;
+
+pub mod node;
+pub mod iterators;
+
+pub use node::{Node, Link};
+
+
+/// A tree struct to encapsulate a bidirectional binary tree.AsMut
+/// 
+/// Each node within the tree has three pointers to its parent, left, and right child. 
+/// 
+/// This struct holds the root of the tree. The tree also contains a size which represents the number of nodes in the tree,
+/// an input size which is the size of the input vector (1D), and is used to generate nodes alone with the 
+/// output options which is an owned vec of i32s represnting different outputs of the classification.
+#[derive(PartialEq)]
+pub struct Tree<T: Clone> {
+    root: Link<T>,
+    size: i32,
+}
+
+/// implement the tree
+impl<T: Clone> Tree<T> {
+    /// Create a new default Tree given an input size and a vec of possible outputs 
+    /// 
+    /// Returns the newly created Tree with no root node, a size of 
+    /// 0 and an owned input_size and output_options.
+    pub fn new() -> Self {
+        Tree {
+            root: None,
+            size: 0,
+        }
+    }
+
+    /// build tree from node slice
+    pub fn from_slice(mut nodes: Vec<Option<T>>) -> Self {
+        let mut tree = Self::new();
+        tree.size = nodes.len() as i32;
+        tree.set_root(tree.make_tree(&mut nodes[..]));
+        tree
+    }
+
+    pub(crate) fn root_mut_opt(&mut self) -> Option<&mut Node<T>> {
+        self.root.as_mut().map(|n| n.as_mut())
+    }
+
+    pub(crate) fn root_opt(&self) -> Option<&Node<T>> {
+        self.root.as_ref().map(|n| n.as_ref())
+    }
+
+    pub(crate) fn set_root(&mut self, root: Link<T>) {
+        self.drop_root();
+        self.root = root;
+    }
+
+    fn drop_root(&mut self) {
+        self.root = None;
+    }
+
+    /// return an in order iterator which 
+    /// allows for the nodes in the tree to be
+    /// mutatued while iterating
+    pub fn iter_mut(&mut self) -> iterators::IterMut<'_, T> {
+        iterators::IterMut::new(self.root_mut_opt())
+    }
+
+    /// Return a level order iterator
+    /// Iterators over the tree from top to bottom, 
+    /// going from parent, to it's left child then it's right child.
+    /// Each node that the iterator yields is a reference to a Node struct
+    pub fn level_order_iter(&self) -> iterators::LevelOrderIterator<'_, T> {
+        iterators::LevelOrderIterator::new(self.root_opt())
+    }
+
+    /// Return an in order iterator
+    /// Iterates over the tree in order, from left to right
+    /// with the root in the middle (assuming balanced)
+    /// Each node that the iterator yields is a reference to a Node struct
+    pub fn in_order_iter(&self) -> iterators::InOrderIterator<'_, T> {
+        iterators::InOrderIterator::new(self.root_opt())
+    }
+
+    /// the len of the tree is it's size, the numbr of nodes
+    pub fn len(&self) -> &i32 {
+        &self.size
+    }
+
+    /// Update size from root node.
+    pub fn update_size(&mut self) {
+        self.size = match self.root_opt() {
+            Some(root) => root.size(),
+            None => 0,
+        };
+    }
+
+    /// return the height of the tree from the root 
+    #[inline]    
+    pub fn height(&self) -> i32 {
+        match self.root_opt() {
+            Some(root) => root.height(),
+            None => 0,
+        }
+    }
+
+    /// Get a node from the tree at a given index and return an option with
+    /// either the node in it, or none. 
+    /// 
+    /// Panic! if the index is greater than the size of the tree.
+    #[inline]    
+    pub fn get(&mut self, index: usize) -> &mut Node<T> {
+        let mut temp: Option<&mut Node<T>> = None;
+        for (i, node) in self.iter_mut().enumerate() {
+            if i == index {
+                temp = Some(node);
+                break;
+            }
+        }
+        temp.unwrap_or_else(|| panic!("Index not found in tree."))
+    }
+
+    /// Get the index of a given node in the tree
+    #[inline]    
+    pub fn index_of(&self, node: &Node<T>) -> usize {
+        let mut temp: Option<usize> = None;
+        for (index, curr) in self.in_order_iter().enumerate() {
+            if curr == node {
+                temp = Some(index);
+                break;
+            }
+        }
+        temp.unwrap_or_else(|| panic!("Node index not found."))
+    }
+
+    /// Insert a node to the tree randomly and increase the size by 1.
+    pub fn insert_random(&mut self, elem: T) {
+        let node = Node::new(elem);
+        match self.root_mut_opt() {
+            Some(root) => {
+                root.insert_random(node);
+            },
+            None => {
+                self.set_root(Some(node));
+            },
+        }
+        self.size += 1;
+    }
+
+    /// display the tree by calling the recursive display method within the node 
+    /// implementation at level 0. If no root node, panic!
+    pub fn display(&self) {
+        match &self.root {
+            None => panic!("The no root node"),
+            Some(root) => root.display(0),
+        }
+    }
+
+    /// Balance the tree by thin copying each node then calling a private
+    /// recursive function to build the tree structure.
+    /// 
+    /// Return an option in order to use '?' instead of 'unwrap()' in the 
+    /// function body.
+    pub fn balance(&mut self) {
+        let mut node_bag = self.in_order_iter()
+            .map(|x: &Node<T>| Some(x.get().clone()))
+            .collect::<Vec<_>>();
+        self.set_root(self.make_tree(&mut node_bag[..]));
+    }
+
+    /// Recursively build a balanced binary tree by splitting the slice into left/right
+    /// sides at the middle node.
+    /// Return a `Link` to the middle node to be set as the child of a parent node or as the root node.
+    #[inline]    
+    fn make_tree(&self, bag: &mut [Option<T>]) -> Link<T> {
+        let midpoint = bag.len() / 2;
+        // split at midpoint
+        let (left, right) = bag.split_at_mut(midpoint);
+        // 'right' side has the node we need.
+        if let Some((node, right)) = right.split_first_mut() {
+            // take the node from the bag.  This replaces it with `None`
+            let mut curr_node = Node::new(node.take().unwrap());
+            // make sure it doesn't have a parent.
+            curr_node.set_left_child(self.make_tree(left));
+            curr_node.set_right_child(self.make_tree(right));
+            Some(curr_node)
+        } else {
+            // bag is empty
+            return None;
+        }
+    }
+
+    /// get a vec of node references in a bised sense where
+    /// nodes at a lower level are favored 
+    #[inline]    
+    pub fn get_biased_level<'a>(&'a self) -> Vec<&'a Node<T>> {
+        let mut r = rand::thread_rng();
+        let index = r.gen_range(0, self.len()) as usize;
+        let levels = self.level_order_iter()
+            .map(|x: &Node<T>| self.height() - x.height())
+            .collect::<Vec<_>>();
+
+        // return a vec where the depth of a node is equal to 
+        // the biased level chosen. Order does not matter
+        // because there will be more numbers in the levels vec with 
+        // a lower depth inherintly due to tree structures
+        self.in_order_iter()
+            .filter(|x| x.depth() == levels[index])
+            .collect::<Vec<_>>()
+    }
+
+    /// Get a biased random node from the tree by gathering a biased random level
+    /// towards the bottom of the tree, then returning a reference to the chosen node
+    pub fn get_biased_random_node<'a>(&'a self) -> &'a Node<T> {
+        let mut nodes = self.get_biased_level();
+        let index = rand::thread_rng().gen_range(0, nodes.len());
+        nodes.remove(index)
+    }
+
+    /// take in an index of the tree to swap with the pointer of another subtree
+    /// by simply switching the pointers of the node at swap_index and the other_node pointer
+    pub(crate) fn replace(&mut self, swap_index: usize, mut other_node: Box<Node<T>>) {
+        let swap_node = self.get(swap_index);
+        match swap_node.parent_mut_opt() {
+            Some(parent) => {
+                if parent.check_left_child(swap_node) {
+                    parent.set_left_child(Some(other_node));
+                } else if parent.check_right_child(swap_node) {
+                    parent.set_right_child(Some(other_node));
+                } else {
+                    unreachable!("Invalid tree structure.  The node is not a child of it's parent.");
+                }
+            },
+            None => {
+                other_node.remove_from_parent();
+                self.set_root(Some(other_node));
+            }
+        }
+        self.update_size();
+    }
+
+    /// Shuffel the tree by gathering a list of the nodes then shuffling the list
+    /// and then balancing the tree again from that list
+    #[inline]    
+    pub fn shuffle_tree(&mut self, r: &mut ThreadRng) {
+        let mut node_list = self.in_order_iter()
+            .map(|x: &Node<T>| Some(x.get().clone()))
+            .collect::<Vec<_>>();
+        node_list.shuffle(r);
+        self.set_root(self.make_tree(&mut node_list[..]));
+    }
+}
+
+/// implemented a display function for the Tree just for easier debugging 
+impl<T: Clone> fmt::Debug for Tree<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Tree=[{}]", self.size)
+    }
+}
+
+/// Return a new copy of the tree, calling deep copy from the root node and copying over
+/// the size, input size, and output options in the most effecient way.
+impl<T: Clone> Clone for Tree<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        // Deep copy root node if any.
+        let root = self.root_opt().map(|n| n.deepcopy());
+        Tree {
+            root,
+            size: self.size,
+        }
+    }
+}
+
+/// Because the tree is made out of raw mutable pointers, if those pointers
+/// are not dropped, there is a severe memory leak, like possibly gigs of
+/// ram over only a few generations depending on the size of the generation
+/// This drop implementation will recursivley drop all nodes in the tree 
+impl<T: Clone> Drop for Tree<T> {
+    fn drop(&mut self) { 
+        self.drop_root();
+    }
+}
+
+/// These must be implemneted for the tree or any type to be 
+/// used within seperate threads. Because implementing the functions 
+/// themselves is dangerious and unsafe and i'm not smart enough 
+/// to do that from scratch, these "implmenetaions" will get rid 
+/// of the error and realistically they don't need to be implemneted for the
+/// program to work
+unsafe impl<T: Clone> Send for Tree<T> {}
+unsafe impl<T: Clone> Sync for Tree<T> {}
+
+/// implement a function for getting a base default Tree which is completetly empty
+/// There are multiple places within the struct implementation which will panic! if 
+/// this default Tree is passed through it.
+impl<T: Clone> Default for Tree<T> {
+    fn default() -> Self {
+        Tree {
+            root: None,
+            size: 0
+        }
+    }
+}

--- a/radiate_matrix_tree/src/tree/node.rs
+++ b/radiate_matrix_tree/src/tree/node.rs
@@ -134,7 +134,7 @@ impl<T: Clone> Node<T> {
     }
 
     /// Safely returns a mutable reference to this node's parent.
-    pub fn parent_mut_opt(&self) -> Option<&mut Node<T>> {
+    pub fn parent_mut_opt(&mut self) -> Option<&mut Node<T>> {
         if self.has_parent() {
             Some(unsafe { &mut *self.parent })
         } else {


### PR DESCRIPTION
The only unsafe left is in the `IterMut` and the parent references.  Down to only 7 unsafe usages in `radiate_matrix_evtree` crate and no unsafe in the other crates.

Split `Evtree` so that the tree code is now generic and separate from the `NeuralNetwork` & `Genome` logic.

Fixed the level order iterator (it was returning all left node first) and added some unit tests to test the iterators.

The only way to remove the remaining unsafe code would be to use something like `Rc<RefCell<>>` and Weak references for the parent.