### PR TITLE
Fix docs, refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ members = [
     "examples/ism",
     "examples/xor-evtree",
     "examples/helloworld",
-		"examples/neat-web/neat-server",
-		"examples/neat-web/neat-client",
+	"examples/neat-web/neat-server",
+	"examples/neat-web/neat-client",
 ]

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ pub struct Hello {
 }
 
 impl Hello {
-    pub fn new(alph: &Vec<char>) -> Self {
+    pub fn new(alph: &[char]) -> Self {
         let mut r = rand::thread_rng();
         Hello { 
             data: (0..12)

--- a/README.md
+++ b/README.md
@@ -6,35 +6,35 @@
 Coming from Evolutionary Radiation.
 > Evolutionary radiation is a rapid increase in the number of species with a common ancestor, characterized by great ecological and morphological diversity - Pascal Neige.
 
-Radiate is a parallel genetic programming engine capable of evolving solutions to many problems as well as training learning algorithms. By seperating the the evolutionary process from the object being evolved, users can evolve any defined structure. The algorithm follows an evolutionary process through speciation which allows structures to optimize within their own niche. 
+Radiate is a parallel genetic programming engine capable of evolving solutions to many problems as well as training learning algorithms. By separating the the evolutionary process from the object being evolved, users can evolve any defined structure. The algorithm follows an evolutionary process through speciation which allows structures to optimize within their own niche.
 
 Radiate exposes three traits to the user which must be implemented (full simple implementation below):
 1. **Genome**  
-Genome wraps the structure to be evolved and makes the user implement two nessesary functions and one optional. Distance and crossover must be implemented but base is optional (depending on how the user chooses to fill the population).
+Genome wraps the structure to be evolved and makes the user implement two necessary functions and an optional one. Distance and crossover must be implemented but base is optional (depending on how the user chooses to fill the population).
 2. **Environment**  
-Environment represnts the evolutionary enviromnet for the genome, this means it can contain simple statistics for the population's evoltuion, or parameters for crossing over and distance. Internally it is wrapped in a mutable threadsafe pointer so it is not intended to be shared for each genome, rather one per population. Environment requires no implementations of it's one function, however depending on the use case envionment exposes a function called reset which is intended to 'reset' the envionment.
+Environment represents the evolutionary environment for the genome, which means it can contain simple statistics for the population's evolution, or parameters for crossover and distance. Internally it is wrapped in a mutable thread-safe pointer so it is not intended to be shared for each genome, but rather exist only once per population. Environment requires no implementations of its one function, however depending on the use case environment exposes a function called reset which is intended to 'reset' the environment.
 3. **Problem**  
-Problem is what gives a genome it's fitness score. It requires two implemented functions: empty and solve. Empty is required and should return a base problem (think new()). Solve takes a genome and returns that genome's fitness score, so this is where the analyzing of the current state of the genome occurs.
+Problem is what gives a genome its fitness score. It requires two implemented functions: empty and solve. Empty is required and should return a base problem (think new()). Solve takes a genome and returns that genome's fitness score, so this is where the analysis of the current state of the genome occurs.
 
-Radiate also comes with one model already built and another available for use on crates. Those being radiate_matrix_tree and NEAT, radiate_matrix_tree is available on crates and NEAT comes prepackaged with radiate.
+Radiate also comes with one model already built in and another one available for use on crates.io. Those being radiate_matrix_tree and NEAT, radiate_matrix_tree is available on crates.io and NEAT comes prepackaged with radiate.
 
 ### NEAT
-Also known as Neuroevolution of Augmented Topologies, is the algorithm described by Kenneth O. Stanley in [this](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf) paper. This NEAT implementation also includes a backpropagation function which operates much like traditional neural networks which propagate the input error back through the network to adjust the weights. In pair with the evolution engine, can produce very nice and quick results. NEAT lets the use define how the network will be constructed, whether that be in a traitional neural network fashion where layers are stacked next to each other or with evolutionary topolgies of the graph through as explained in the paper. This means NEAT can be used in an evolutionary sense, through forward propagation and back propagation, or any combination of the two. There are examples of both in /examples.
+Also known as Neuroevolution of Augmented Topologies, is the algorithm described by Kenneth O. Stanley in [this](http://nn.cs.utexas.edu/downloads/papers/stanley.ec02.pdf) paper. This NEAT implementation also includes a backpropagation function which operates much like traditional neural networks which propagate the input error back through the network to adjust the weights. In pair with the evolution engine, this can produce very nice and quick results. NEAT lets the use define how the network will be constructed, whether that be in a traditional neural network fashion where layers are stacked next to each other or with evolutionary topologies as explained in the paper. This means NEAT can be used in an evolutionary sense, through forward propagation and back propagation, or any combination of the two. There are examples of both in /examples.
  **more color on Neat in radiate/src/models/**
 
  Radiate also supports off-machine training where you can set up a problem to solve on one machine, then send the parameters to it from another through [Radiate Web](https://github.com/pkalivas/radiate/tree/master/radiate_web).
 
 ## Setup
-The population is pretty easy to set up assuming the all traits have been implemented. The population is a higher abstraction to keep track of varibales used during evoltuion but not needed within epoch - things like the problem, solution, to print to the screen, ect. A new population is filled originally with default settings:
+The population is pretty easy to set up assuming the all traits have been implemented. The population is a higher abstraction to keep track of variables used during evolution but not needed within an epoch - things like the problem, solution, printing to the screen etc. A new population is filled initially with default settings:
 ```rust
 pub fn new() -> Self {   
     Population {
         // define the number of members to participate in evolution and be injected into the current generation
         size: 100,
-        // determin if the species should be aiming for a specific number of species by adjusting the distance threshold
+        // determine if the species should be aiming for a specific number of species by adjusting the distance threshold
         dynamic_distance: false,
         // debug_progress is only used to print out some information from each generation
-        // to the console during training to get a glimps into what is going on
+        // to the console during training to get a glimpse of what is going on
         debug_progress: false,
         // create a new config to help the speciation of the population
         config: Config::new(),
@@ -43,12 +43,12 @@ pub fn new() -> Self {
         // keep track of fitness score stagnation through the population
         stagnation: Stagnant::new(0, Vec::new()),
         // Arc<Problem> so the problem can be sent between threads safely without duplicating the problem, 
-        // if the problem gets duplicated every time a supervised learning problem with a lot of data could take up a ton of memory
+        // if the problem gets duplicated every time, a supervised learning problem with a lot of data could take up a large amount of memory
         solve: Arc::new(P::empty()),
-        // create a new solver settings that will hold the specific settings for the defined solver 
+        // create new solver settings which will hold the specific settings for the defined solver 
         // that will allow the structure to evolve through generations
         environment: Arc::new(RwLock::new(E::default())),
-        // determine which genomes will live on and passdown to the next generation
+        // determine which genomes will live on and pass down to the next generation
         survivor_criteria: SurvivalCriteria::Fittest,
         // determine how to pick parents to reproduce
         parental_criteria: ParentalCriteria::BiasedRandom
@@ -97,7 +97,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 ```
 Now create the problem which holds the target and actually scores the solvers. 
-Note the target data isn't being coppied for each solver.
+Note that the target data isn't being copied for each solver.
 ```rust
 pub struct World { target: Vec<char> }
 
@@ -139,7 +139,7 @@ impl HelloEnv {
     }
 }
 
-/// implement Environment and default for the HelloEnv, Environment is there in case you want the environment to be dynamic
+/// implement Environment and Default for the HelloEnv, Environment is there in case you want the environment to be dynamic
 impl Envionment for HelloEnv {}
 impl Default for HelloEnv {
     fn default() -> Self {
@@ -213,7 +213,7 @@ impl Genome<Hello, HelloEnv> for Hello {
     }
 }
 ```
-Running this looks something like this when running in the cmd:
+The result looks something like this when running on the command line:
 ```bash
 Generation: 100 score: 8.000    "!eulozworlde"
 Generation: 101 score: 8.000    "!eulozworlde"
@@ -245,7 +245,7 @@ Generation: 126 score: 12.000   "hello world!"
 
 Time in millis: 349, solution: "hello world!"
 ```
-This comes right now with four examples, just run "cargo run --bin (desired example name)" to run any of them
+Right now there are four examples, just run "cargo run --bin (desired example name)" to run any of them
 1. **xor-neat**
 2. **xor-neat-backprop**
 3. **lstm-neat**
@@ -256,13 +256,13 @@ The initial generation in the population can be created in four different ways d
 1. **populate_gen** - Give the population an already constructed Generation struct. 
 2. **populate_base** - Create a generation of Genomes from the Genome's base function.
 3. **populate_vec** - Take a vec and populate the generation from the Genomes in the vec.
-4. **populate_clone** - Given a single Genome, clone it size times and create a generation from the clones.
+4. **populate_clone** - Given a single Genome, clone it `size` times and create a generation from the clones.
 
 ## Speciation
 Because the engine is meant to evolve Genomes through speciation, the Config struct is meant to hold parameters for the speciation of the population, adjusting these will change the way the Genomes are split up within the population and thus drive the discovery of new Genomes through crossover and mutation.
 
 ## Genocide
-During evolution it can be common for either the population or specific species to become stagnat or stuck at a certain point in the problem space. To mend this, population allows the user to define a number of stagnant generations until a 'genocide' will occur. These genocide options can be found in genocide.rs and are simply ways to clean the population to give the Genome's an opportunity to breath and evolve down a new path in the problem space. 
+During evolution it can be common for either the population or specific species to become stagnant or stuck at a certain point in the problem space. To break out of this, `population` allows the user to define a number of stagnant generations until a 'genocide' will occur. These genocide options can be found in genocide.rs and are simply ways to clean the population to give the genomes an opportunity to breathe and evolve down a new path in the problem space.
 ```rust
 pub enum Genocide {
     KeepTop(usize),
@@ -271,16 +271,16 @@ pub enum Genocide {
     KillOldestSpecies(usize)
 }
 ```
-This is definitly an area which can be improved in the algorithm.
+This is definitely an area which can be improved in the algorithm.
 
 ## Versions
-**1.5.57** - Major improvements to the Dense/DensePool layers. Before the improvement the benchmark takes about 1.5 minutes to run. With the improvements it finishes in about 1.5 seconds.
+**1.5.57** - Major improvements to the Dense/DensePool layers. Before the improvement the benchmark took about 1.5 minutes to run. With the improvements it finishes in about 1.5 seconds.
 
 **1.1.55** - Removed unsafe code and fixed memory leak in evtree. Refactored Evtree to be generic, moving neural network logic to be separate. Cleaned up send/sync impls.
 
 **1.1.52** - Added recurrent neurons for NEAT. Note - this is also only viable for evolution (I will focus on implementing backprop for recurrent neurons and GRU layers next - I'm working on some other projects that require recurrent evolution neurons as of now). This can be configured in the NeatEnvironment settings where the % change of adding a recurrent neuron can be added. 0.0 would mean no recurrent neurons are added, where 1.0 would mean every new neuron is recurrent. Example in radiate/src/models/.
 
-**1.1.5** - Added minimal support for GRU layer (Gated Recurrent Unit). GRU is only viable for evolution, NOT backprop, yet. Your program will panic! if a network with a gru layer is used during backprop, if a memory cell is needed for backprop purposes use the LSTM option for now. Also, cleaned up some code and optimized certain points to run a bit quicker. Evtree has been moved to it's own seperate crate called radiate_matrix_tree and is available on crates.io.
+**1.1.5** - Added minimal support for GRU layer (Gated Recurrent Unit). GRU is only viable for evolution, NOT backprop, yet. Your program will panic! if a network with a gru layer is used during backprop, if a memory cell is needed for backprop purposes use the LSTM option for now. Also, cleaned up some code and optimized certain points to run a bit quicker. Evtree has been moved to it's own separate crate called radiate_matrix_tree and is available on crates.io.
 
 **1.1.3** - Adding support for [Radiate Web](https://github.com/pkalivas/radiate/tree/master/radiate_web) so training Radiate can be done on a different machine.
 

--- a/examples/helloworld/src/main.rs
+++ b/examples/helloworld/src/main.rs
@@ -97,7 +97,7 @@ pub struct Hello {
 }
 
 impl Hello {
-    pub fn new(alph: &Vec<char>) -> Self {
+    pub fn new(alph: &[char]) -> Self {
         let mut r = rand::thread_rng();
         Hello { data: (0..12).map(|_| alph[r.gen_range(0, alph.len())]).collect() }
     }

--- a/examples/ism/src/main.rs
+++ b/examples/ism/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // set the number of threads to be used
     rayon::ThreadPoolBuilder::new().num_threads(8).build_global().unwrap();
 
-    // definie the environment
+    // define the environment
     let neat_env = NeatEnvironment::new()
         .set_weight_mutate_rate(0.8)
         .set_edit_weights(0.1)

--- a/examples/ism/src/main.rs
+++ b/examples/ism/src/main.rs
@@ -107,7 +107,7 @@ impl ISM {
     }
 
 
-    fn minimum(nums: &Vec<Vec<f32>>) -> f32 {
+    fn minimum(nums: &[Vec<f32>]) -> f32 {
         nums.iter()
             .fold(1000.0, |min, curr| {
                 if curr[0] < min {
@@ -118,7 +118,7 @@ impl ISM {
     }
 
 
-    fn maximum(nums: &Vec<Vec<f32>>) -> f32 {
+    fn maximum(nums: &[Vec<f32>]) -> f32 {
         nums.iter()
             .fold(-1000.0, |max, curr| {
                 if curr[0] > max {

--- a/examples/lstm-neat/src/main.rs
+++ b/examples/lstm-neat/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let starting_net = Neat::new()
         .input_size(1)
         .batch_size(data.output.len())
-        // .gru(10, 5, Activation::Tahn)
+        // .gru(10, 5, Activation::Tanh)
         .dense_pool(1, Activation::Sigmoid);
         // .lstm(10, 1, Activation::Sigmoid);
 

--- a/examples/xor-evtree/src/main.rs
+++ b/examples/xor-evtree/src/main.rs
@@ -7,14 +7,14 @@ use std::error::Error;
 use std::time::Instant;
 use simple_matrix::Matrix;
 use radiate::prelude::*;
-use radiate_matrix_tree::prelude::{Evtree, TreeEnvionment, defualt_evtree_env};
+use radiate_matrix_tree::prelude::{Evtree, TreeEnvionment, default_evtree_env};
 
 
 
 fn main() -> Result<(), Box<dyn Error>> {
 
     let thread_time = Instant::now();
-    let tree_env = defualt_evtree_env();        
+    let tree_env = default_evtree_env();
     Population::<Evtree, TreeEnvionment, XOR>::new()
         .impose(XOR::new())
         .constrain(tree_env)

--- a/radiate/src/engine/generation.rs
+++ b/radiate/src/engine/generation.rs
@@ -18,15 +18,15 @@ use super::{
 /// just the type T, where it has an owning reference counter
 /// then wrapped in a ref cell to allow for mutable borrowing of the Rc
 pub type Member<T> = Arc<RwLock<T>>;
-/// the MemberWeak is meant to be a Nonowning member type pointing to the 
+/// the MemberWeak is meant to be a non-owning member type pointing to the
 /// same memory space but not having the same owning ability of the data
 pub type MemberWeak<T> = Weak<RwLock<T>>;
 
-/// A family is a wrapper for a species type which ownes the data it 
+/// A family is a wrapper for a species type which owns the data it
 /// holds. This is needed as there are many references to a species 
 /// throughout the program
 pub type Family<T, E> = Arc<RwLock<Niche<T, E>>>;
-/// the FamilyWeak is meant to mimic the MemberWeak as it is a nonowning family
+/// the FamilyWeak is meant to mimic the MemberWeak as it is a non-owning family
 /// type which allows for multiple bi-directional pointers to the same Niche 
 /// type in the same memory location
 pub type FamilyWeak<T, E> = Weak<RwLock<Niche<T, E>>>;
@@ -70,8 +70,8 @@ impl<T, E> Container<T, E>
 
 
 /// A generation is meant to facilitate the speciation, crossover, and 
-/// reproduction of spececies and their types over the course of a single 
-/// genertion
+/// reproduction of species and their types over the course of a single
+/// generation
 #[derive(Debug)]
 pub struct Generation<T, E> 
     where
@@ -105,7 +105,7 @@ impl<T, E> Generation<T, E>
         }
     }
 
-    /// passdown the previous generation's members and species to a new generation
+    /// pass down the previous generation's members and species to a new generation
     #[inline]
     pub fn pass_down(&self, new_members: Vec<Member<T>>) -> Option<Self> {
         Some(Generation {
@@ -198,11 +198,11 @@ impl<T, E> Generation<T, E>
     /// Create the next generation and return a new generation struct with 
     /// new members, and reset species. This is how the generation moves from
     /// one to the next. This function also is the one which runs the crossover
-    /// fn from the genome trait, the more effecent that function is, the faster
+    /// fn from the genome trait, the more efficient that function is, the faster
     /// this function will be.
     #[inline]
     pub fn create_next_generation(&mut self, pop_size: i32, config: Config, env: Arc<RwLock<E>>) -> Option<Self> {   
-        // generating new members in a biased way using rayon to parallize it
+        // generating new members in a biased way using rayon to parallelize it
         // then crossover to fill the rest of the generation 
         let mut new_members = self.survival_criteria.pick_survivers(&mut self.members, &self.species)?;
         let children = (new_members.len() as i32..pop_size)
@@ -218,7 +218,7 @@ impl<T, E> Generation<T, E>
                 Arc::new(RwLock::new(child))
             })
             .collect::<Vec<_>>();
-        // reset the species and passdown the new members to a new generation
+        // reset the species and pass down the new members to a new generation
         new_members.extend(children);
         self.pass_down(new_members)
     }

--- a/radiate/src/engine/generation.rs
+++ b/radiate/src/engine/generation.rs
@@ -204,7 +204,7 @@ impl<T, E> Generation<T, E>
     pub fn create_next_generation(&mut self, pop_size: i32, config: Config, env: Arc<RwLock<E>>) -> Option<Self> {   
         // generating new members in a biased way using rayon to parallelize it
         // then crossover to fill the rest of the generation 
-        let mut new_members = self.survival_criteria.pick_survivers(&mut self.members, &self.species)?;
+        let mut new_members = self.survival_criteria.pick_survivors(&mut self.members, &self.species)?;
         let children = (new_members.len() as i32..pop_size)
             .into_par_iter()
             .map(|_|{

--- a/radiate/src/engine/genocide.rs
+++ b/radiate/src/engine/genocide.rs
@@ -1,5 +1,5 @@
 /// Provide options for cleaning up the population or applying 
-/// some sort of natural selection over the population thorugh time
+/// some sort of natural selection over the population through time
 
 extern crate rayon;
 extern crate rand;  
@@ -14,8 +14,8 @@ use super::niche::{NicheMember};
 
 
 
-/// Definine genocide struct to provide options
-/// of what to do when a population is stagnent,
+/// Define genocide struct to provide options
+/// of what to do when a population is stagnant,
 /// ie: how to clean the population
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Genocide {
@@ -97,7 +97,7 @@ impl Genocide {
 
     /// Kill the bottom prec of each species in the generation. ie: if a species has 10 members 
     /// and the prec is .2, then the bottom two members of this generation will be removed
-    /// this function will run in parallel so it sould be fairly quick
+    /// this function will run in parallel so it should be fairly quick
     fn kill_species_bottom<T, E>(&self, generation: &mut Generation<T, E>, perc: f32)
         where 
             T: Genome<T, E> + Send + Sync,

--- a/radiate/src/engine/mod.rs
+++ b/radiate/src/engine/mod.rs
@@ -7,7 +7,7 @@ pub mod survival;
 
 
 /// Genome is what will actually be evolved through the engine, 
-/// this is going to be whatever datastructure should be optimized
+/// this is going to be whatever data structure should be optimized
 pub mod genome {
     
     use super::environment::Envionment;
@@ -23,21 +23,21 @@ pub mod genome {
         /// a new type, this is done through some defined form of 
         /// mutation using the config type, or through crossover 
         /// where parts of one type are given to parts of the other and that resulting
-        /// type is returnd
+        /// type is returned
         fn crossover(one: &T, two: &T, env: Arc<RwLock<E>>, crossover_rate: f32) -> Option<T> 
             where 
                 T: Sized,
                 E: Envionment + Sized;
         
-                /// This is a measure of a evolutionary types structure or topology - depending on what is being evolved.
+        /// This is a measure of an evolutionary type's structure or topology - depending on what is being evolved.
         /// This is needed to split the members in their respective species - essentially it is 
         /// a measure of how far away two types are from each other in a genetic 
-        /// sense. Think of something like how similar humans are to dolphins, this is a way to quanitfy that.
+        /// sense. Think of something like how similar humans are to dolphins, this is a way to quantify that.
         fn distance(one: &T, two: &T, env: Arc<RwLock<E>>) -> f32;
         
         /// Genome needs to have a base implementation in order for one of the population options to be satisfied
         /// 
-        /// This can probably be iplemented in a generic way for default if the user doesn't want to 
+        /// This can probably be implemented in a generic way for default if the user doesn't want to
         /// implement it for their problem. 
         fn base(_: &mut E) -> T
             where T: Sized
@@ -51,14 +51,14 @@ pub mod genome {
 
 /// Environment represents overall settings for a genome, this can be statistics to be 
 /// tracked through evolution, or things like mutation rates or global counters. This is 
-/// injected into functions throughou the generational process so it is acessable globally as a
+/// injected into functions throughout the generational process so it is accessible globally as a
 /// center point for the evolution. Note - if this is to be used a mutable in crossover or mutation, 
 /// this will slow down the optimization process as it will have to be locked during the writing thus
-/// having the vairiables in the implementatino of this trait be readonly is preferred but isn't that big of a deal
+/// having the variables in the implementation of this trait be readonly is preferred but isn't that big of a deal
 pub mod environment {
     pub trait Envionment {
         
-        /// Reset can be used to reset the enviromnet after a certain event occurs,
+        /// Reset can be used to reset the environment after a certain event occurs,
         /// if not this is an empty default implementation
         fn reset(&mut self) { }
     
@@ -69,11 +69,11 @@ pub mod environment {
 
 /// Problem is the actual problem to be solved.
 /// This is wrapped in an Arc pointer due to the problem not wanting to be 
-/// coppied through threads. This was done intentially because I wanted to be able to 
+/// copied through threads. This was done intentionally because I wanted to be able to
 /// represent supervised, unsupervised, and general reinforcement learning problems. This
 /// means if you are using a supervised system and have a large dataset to analyze, if this 
 /// dataset is stored in the problem (as they should be), without an Arc pointer this large dataset would 
-/// be coppied multiple times and take up massive amounts of memory. The Arc allows us to keep only one version
+/// be copied multiple times and take up massive amounts of memory. The Arc allows us to keep only one version
 /// of the problem and share that between threads. Note - this means everything in the problem and all it's data
 /// is explicitly readonly 
 pub mod problem {
@@ -85,7 +85,7 @@ pub mod problem {
         fn empty() -> Self;
         
         /// Solve is what actually solves the problem , given a solver (the genome type)
-        /// use the data in the type implementing the problem to sovle the problem and return
+        /// use the data in the type implementing the problem to solve the problem and return
         /// the member's score. The result of this function is the member's fitness score 
         fn solve(&self, member: &mut T) -> f32;
     }

--- a/radiate/src/engine/niche.rs
+++ b/radiate/src/engine/niche.rs
@@ -20,7 +20,7 @@ use super::genome::{Genome};
 pub struct NicheMember<T>(pub f32, pub MemberWeak<T>);
 
 
-/// A species is meant to keep track of fitness scores of eachof it's members,
+/// A species is meant to keep track of fitness scores of each of it's members,
 /// and a mascot. The mascot is the representation of the species by a Type 
 /// member in the population. It also holds the number of age it's been
 /// alive
@@ -77,10 +77,10 @@ impl<T, E> Niche<T, E>
 
 
 
-    /// Reset the species by getting a new random mascot and incrememnting the 
+    /// Reset the species by getting a new random mascot and incrementing the
     /// age by one, then setting the total adjusted species back to None,
     /// and clearing the members vec. Basically starting from scratch again but 
-    /// need to incremement a few small things to keep track of the species
+    /// need to increment a few small things to keep track of the species
     pub fn reset(&mut self) {
         let new_mascot = self.members.choose(&mut rand::thread_rng());
         match new_mascot {
@@ -96,8 +96,8 @@ impl<T, E> Niche<T, E>
 
 
 
-    // for species sizes which are large and populations holding mutliple species,
-    // it makes sense to just calcuate this once then retreive the the value 
+    // for species sizes which are large and populations holding multiple species,
+    // it makes sense to just calculate this once then retrieve the the value
     // instead of calculate it every time it's needed. Its a quick and simple operation
     pub fn calculate_total_adjusted_fitness(&mut self) {
         let length = self.members.len() as f32;

--- a/radiate/src/engine/population.rs
+++ b/radiate/src/engine/population.rs
@@ -29,10 +29,10 @@ struct Stagnant {
 
 
 /// This is just to keep track of a few parameters for 
-/// the population, this encapsulates a few arguments for speication 
+/// the population, this encapsulates a few arguments for speciation
 /// in the algorithm, these are specific to genetic algorithms 
 /// which implement speciation between members of the population.
-/// It also leaves room for more paramters to be added in the future.
+/// It also leaves room for more parameters to be added in the future.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub inbreed_rate: f32,
@@ -68,7 +68,7 @@ pub struct Population<T, E, P>
 
 
 
-/// implmenet the population
+/// implement the population
 impl<T, E, P> Population<T, E, P>
     where
         T: Genome<T, E> + Send + Sync + Clone,
@@ -84,7 +84,7 @@ impl<T, E, P> Population<T, E, P>
             // determin if the species should be aiming for a specific number of species by adjusting the distance threshold
             dynamic_distance: false,
             // debug_progress is only used to print out some information from each generation
-            // to the console during training to get a glimps into what is going on
+            // to the console during training to get a glimpse into what is going on
             debug_progress: false,
             // create a new config to help the speciation of the population
             config: Config::new(),
@@ -98,7 +98,7 @@ impl<T, E, P> Population<T, E, P>
             // create a new solver settings that will hold the specific settings for the defined solver 
             // that will allow the structure to evolve through generations
             environment: Arc::new(RwLock::new(E::default())),
-            // determine which genomes will live on and passdown to the next generation
+            // determine which genomes will live on and pass down to the next generation
             survivor_criteria: SurvivalCriteria::Fittest,
             // determine how to pick parents to reproduce
             parental_criteria: ParentalCriteria::BiasedRandom
@@ -157,7 +157,7 @@ impl<T, E, P> Population<T, E, P>
         Some((top_member.0, (*top_member.1).clone()))
     }
 
-    /// Check to see if the population is stagnant or not, if it is 
+    /// Check to see if the population is stagnant or not, if it is,
     /// then go ahead and clean the population 
     fn manage_stagnation(&mut self, curr_top_score: f32) {
         if self.stagnation.target_stagnation == self.stagnation.current_stagnation {
@@ -173,7 +173,7 @@ impl<T, E, P> Population<T, E, P>
         self.stagnation.previous_top_score = curr_top_score;
     }
 
-    /// dynamically adjust the distance of a popualtion 
+    /// dynamically adjust the distance of a population
     fn adjust_distance(&mut self) {
         if self.curr_gen.species.len() < self.config.species_target {
             self.config.distance -= 0.1;
@@ -224,15 +224,15 @@ impl<T, E, P> Population<T, E, P>
     
     /////////////////////////////////////////////////////////////////////////////////////////////////////////
     /// configure all the settings for the population these all have default settings if they are not set ///
-    /// customly, however you might find those default settings do not satisfy the needs of your problem  ///
+    /// by hand, however you might find those default settings do not satisfy the needs of your problem   ///
     /////////////////////////////////////////////////////////////////////////////////////////////////////////
     
-    /// Set the beginning generation of the population by a generion object
+    /// Set the beginning generation of the population by a generation object
     /// this can be done in three ways all listed below.
     /// 
     /// 1.) populate_gen - Create a generation object outsize of this scope and give it to the 
-    ///                    population, return the popuolation back to the caller
-    /// 2.) populate_base - as long as the popualtion size has already been set and the type T has 
+    ///                    population, return the population back to the caller
+    /// 2.) populate_base - as long as the population size has already been set and the type T has
     ///                     implemented the base trait fn, this will generate a new base generation
     /// 3.) populate_vec - Give the population a vec of type T and generate a new generation from it 
     ///                    then return the population back to the caller
@@ -310,7 +310,7 @@ impl<T, E, P> Population<T, E, P>
         self
     }
 
-    /// Give solver settings to the population to evolve the strucutre defined 
+    /// Give solver settings to the population to evolve the structure defined
     pub fn constrain(mut self, environment: E) -> Self {
         self.environment = Arc::new(RwLock::new(environment));
         self
@@ -353,7 +353,7 @@ impl<T, E, P> Population<T, E, P>
     /// give the population a problem to solve. This 
     /// will default to an empty problem, meaning the population
     /// will not solve anything if this isn't set. This is really
-    /// the most important arguemnt for the population
+    /// the most important argument for the population
     pub fn impose(mut self, prob: P) -> Self {
         self.solve = Arc::new(RwLock::new(prob));
         self
@@ -365,7 +365,7 @@ impl<T, E, P> Population<T, E, P>
         self
     }
 
-    /// give the population a survival cirteria, if none is supplied then it 
+    /// give the population a survival criteria, if none is supplied then it
     /// defaults to the fittest genome from each species
     pub fn survivor_criteria(mut self, survive: SurvivalCriteria) -> Self {
         self.survivor_criteria = survive;
@@ -373,7 +373,7 @@ impl<T, E, P> Population<T, E, P>
     }
 
     /// give the population a way to pick the parents, if none is supplied 
-    /// then default to biasedrandom genomes 
+    /// then default to biased random genomes
     pub fn parental_criteria(mut self, parents: ParentalCriteria) -> Self {
         self.parental_criteria =parents;
         self

--- a/radiate/src/engine/survival.rs
+++ b/radiate/src/engine/survival.rs
@@ -63,7 +63,7 @@ impl SurvivalCriteria {
 
     /// Based on the survival criteria, given a vec of containers and families, pick who survives
     #[inline]
-    pub fn pick_survivors<T, E>(&self, members: &mut Vec<Container<T, E>>, families: &Vec<Family<T, E>>) -> Option<Vec<Arc<RwLock<T>>>>
+    pub fn pick_survivors<T, E>(&self, members: &mut [Container<T, E>], families: &[Family<T, E>]) -> Option<Vec<Arc<RwLock<T>>>>
         where
             T: Genome<T, E> + Send + Sync + Clone,
             E: Send + Sync
@@ -87,7 +87,7 @@ impl SurvivalCriteria {
     #[deprecated = "Use `pick_survivors`"]
     #[doc(hidden)]
     #[inline]
-    pub fn pick_survivers<T, E>(&self, members: &mut Vec<Container<T, E>>, families: &Vec<Family<T, E>>) -> Option<Vec<Arc<RwLock<T>>>>
+    pub fn pick_survivers<T, E>(&self, members: &mut [Container<T, E>], families: &[Family<T, E>]) -> Option<Vec<Arc<RwLock<T>>>>
         where
             T: Genome<T, E> + Send + Sync + Clone,
             E: Send + Sync
@@ -100,12 +100,12 @@ impl SurvivalCriteria {
     /// TopNumber and TopPercent are basically the same so this function does the job of both of them,
     /// just convert the percent to a number before calling the function
     #[inline]
-    fn get_top_num<T, E>(num_to_keep: usize, members: &mut Vec<Container<T, E>>) -> Option<Vec<Arc<RwLock<T>>>>
+    fn get_top_num<T, E>(num_to_keep: usize, members: &mut [Container<T, E>]) -> Option<Vec<Arc<RwLock<T>>>>
         where
             T: Genome<T, E> + Send + Sync + Clone,
             E: Send + Sync
     {
-        members.as_mut_slice()
+        members
             .par_sort_by(|a, b| {
                 b.fitness_score.partial_cmp(&a.fitness_score).unwrap()
             });
@@ -126,7 +126,7 @@ impl ParentalCriteria {
 
     /// Find two parents to crossover and produce a child
     #[inline]
-    pub fn pick_parents<T, E>(&self, inbreed_rate: f32, families: &Vec<Family<T, E>>) -> Option<((f32, Member<T>), (f32, Member<T>))> 
+    pub fn pick_parents<T, E>(&self, inbreed_rate: f32, families: &[Family<T, E>]) -> Option<((f32, Member<T>), (f32, Member<T>))>
         where
             T: Genome<T, E> + Send + Sync + Clone,
             E: Send + Sync 
@@ -150,7 +150,7 @@ impl ParentalCriteria {
     /// parents and returns a tuple of tuples where the f32 is the parent's fitness,
     /// and the type is the parent itself
     #[inline]
-    fn create_match<T, E>(&self, inbreed_rate: f32, families: &Vec<Family<T, E>>) -> ((f32, Member<T>), (f32, Member<T>)) 
+    fn create_match<T, E>(&self, inbreed_rate: f32, families: &[Family<T, E>]) -> ((f32, Member<T>), (f32, Member<T>))
         where
             T: Genome<T, E> + Send + Sync + Clone,
             E: Send + Sync
@@ -182,7 +182,7 @@ impl ParentalCriteria {
     /// Statistically this allows for species with larger adjusted fitnesses to
     /// have a greater change of being picked for breeding
     #[inline]
-    fn get_biased_random_species<T, E>(&self, r: &mut ThreadRng, families: &Vec<Family<T, E>>) -> Option<Family<T, E>> 
+    fn get_biased_random_species<T, E>(&self, r: &mut ThreadRng, families: &[Family<T, E>]) -> Option<Family<T, E>>
         where 
             T: Genome<T, E> + Send + Sync + Clone,
             E: Send + Sync

--- a/radiate/src/engine/survival.rs
+++ b/radiate/src/engine/survival.rs
@@ -15,15 +15,15 @@ use super::genome::Genome;
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Note these should not be directly exposed to the user as to avoid confusion with   ///
 /// too many knobs to turn to create a population. Instead, provide functions to add   ///
-/// them and defaults if they are not added. These are not nessesarily needed options, ///
+/// them and defaults if they are not added. These are not necessarily needed options, ///
 /// they are add-ons and really only for if you really want to test around with your   ///
-/// structure that is evolving, provides users with more options wich is always good   ///
+/// structure that is evolving, provides users with more options which is always good  ///
 //////////////////////////////////////////////////////////////////////////////////////////
 
 
 
 /// Implement a way to pick which way to pick those members who 
-/// survice each generation, in other words - pick who gets to stay, 
+/// survive each generation, in other words - pick who gets to stay,
 /// those who do not get to stay 'die off' and are replaced by the children
 /// 
 /// Fittest - the default option, the top member from each species
@@ -39,7 +39,7 @@ pub enum SurvivalCriteria {
 
 /// Implement a way to pick parents of children, in other words
 /// how is the rest of the population generation after those who 
-/// don't survice die out.
+/// don't survive die out.
 /// 
 /// BiasedRandom - the default option, statistically pick more fit parents
 ///                however allow for less fit parents to be picked as well. This is 
@@ -61,8 +61,9 @@ pub enum ParentalCriteria {
 impl SurvivalCriteria {
 
 
-    /// Based on the survival critera, given a vec of containers and families, pick who survives
+    /// Based on the survival criteria, given a vec of containers and families, pick who survives
     #[inline]
+    // TODO: Fix name (survivors) and deprecate original
     pub fn pick_survivers<T, E>(&self, members: &mut Vec<Container<T, E>>, families: &Vec<Family<T, E>>) -> Option<Vec<Arc<RwLock<T>>>>
         where
             T: Genome<T, E> + Send + Sync + Clone,
@@ -86,7 +87,7 @@ impl SurvivalCriteria {
 
 
 
-    /// TopNumer and TopPercent are basically the same so this function does the job of both of them,
+    /// TopNumber and TopPercent are basically the same so this function does the job of both of them,
     /// just convert the percent to a number before calling the function
     #[inline]
     fn get_top_num<T, E>(num_to_keep: usize, members: &mut Vec<Container<T, E>>) -> Option<Vec<Arc<RwLock<T>>>>
@@ -109,7 +110,7 @@ impl SurvivalCriteria {
 
 
 
-/// implement the pick parents
+/// implement picking parents
 impl ParentalCriteria {
 
 
@@ -166,9 +167,9 @@ impl ParentalCriteria {
 
     /// get a biased random species from the population to get members from
     /// this gets a random species by getting the total adjusted fitness of the 
-    /// entire population then finding a random number inside (0, total populatin fitness)
-    /// then summing the individual species until they hit that random numer 
-    /// Statistically this allows for species with larger adjusted fitnesses to 
+    /// entire population then finding a random number inside (0, total population fitness)
+    /// then summing the individual species until they hit that random number
+    /// Statistically this allows for species with larger adjusted fitnesses to
     /// have a greater change of being picked for breeding
     #[inline]
     fn get_biased_random_species<T, E>(&self, r: &mut ThreadRng, families: &Vec<Family<T, E>>) -> Option<Family<T, E>> 
@@ -177,7 +178,7 @@ impl ParentalCriteria {
             E: Send + Sync
     {
         // set a result option to none, this will panic! if the result is still none
-        // at the end of the function. Then get the total poopulation fitness
+        // at the end of the function. Then get the total population fitness
         let mut result = None;
         let total = families.iter()
             .fold(0.0, |sum, curr| {
@@ -202,7 +203,7 @@ impl ParentalCriteria {
 
 
     /// Get a biased random member from the species. By summing the fitness scores of the 
-    /// members, members with larger fitness scorese are statistically more likely to be picked
+    /// members, members with larger fitness scores are statistically more likely to be picked
     #[inline]
     pub fn get_biased_random_member<T, E>(&self, r: &mut ThreadRng, family: &Family<T, E>) -> (f32, Member<T>)
         where

--- a/radiate/src/engine/survival.rs
+++ b/radiate/src/engine/survival.rs
@@ -40,19 +40,19 @@ pub enum SurvivalCriteria {
 /// Implement a way to pick parents of children, in other words
 /// how is the rest of the population generation after those who 
 /// don't survive die out.
-/// 
-/// BiasedRandom - the default option, statistically pick more fit parents
-///                however allow for less fit parents to be picked as well. This is 
-///                kinda like putting the members in a species on a curve and randomly 
-///                picking from that distribution 
-/// OnlySurvivers - those who survive are only allowed to reproduce
-/// BestInEachSpecies - only the best in each species are allowed to reproduce
-/// MostDifferent - Pick one parent, then find the parent most different from it (structurally) 
-///                 and use that as the other parent. Note this could lead to large expansion in population
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ParentalCriteria {
+    /// The default option, statistically pick more fit parents
+    /// however allow for less fit parents to be picked as well. This is
+    /// kinda like putting the members in a species on a curve and randomly
+    /// picking from that distribution
     BiasedRandom,
+    /// Only the best in each species are allowed to reproduce
     BestInSpecies,
+    // Not implemented:
+    // OnlySurvivors - those who survive are only allowed to reproduce
+    // MostDifferent - Pick one parent, then find the parent most different from it (structurally)
+    //                 and use that as the other parent. Note this could lead to large expansion in population
 }
 
 

--- a/radiate/src/engine/survival.rs
+++ b/radiate/src/engine/survival.rs
@@ -63,8 +63,7 @@ impl SurvivalCriteria {
 
     /// Based on the survival criteria, given a vec of containers and families, pick who survives
     #[inline]
-    // TODO: Fix name (survivors) and deprecate original
-    pub fn pick_survivers<T, E>(&self, members: &mut Vec<Container<T, E>>, families: &Vec<Family<T, E>>) -> Option<Vec<Arc<RwLock<T>>>>
+    pub fn pick_survivors<T, E>(&self, members: &mut Vec<Container<T, E>>, families: &Vec<Family<T, E>>) -> Option<Vec<Arc<RwLock<T>>>>
         where
             T: Genome<T, E> + Send + Sync + Clone,
             E: Send + Sync
@@ -83,6 +82,17 @@ impl SurvivalCriteria {
                 SurvivalCriteria::get_top_num(num_to_survive, members)
             }
         }
+    }
+
+    #[deprecated = "Use `pick_survivors`"]
+    #[doc(hidden)]
+    #[inline]
+    pub fn pick_survivers<T, E>(&self, members: &mut Vec<Container<T, E>>, families: &Vec<Family<T, E>>) -> Option<Vec<Arc<RwLock<T>>>>
+        where
+            T: Genome<T, E> + Send + Sync + Clone,
+            E: Send + Sync
+    {
+        self.pick_survivors(members, families)
     }
 
 

--- a/radiate/src/lib.rs
+++ b/radiate/src/lib.rs
@@ -1,5 +1,5 @@
 
-/// Bring everything in the lib into scope
+// Bring everything in the lib into scope
 
 pub mod prelude;
 pub mod models;
@@ -41,8 +41,9 @@ pub use engine::{
 };
 
 
-/// Defualt enviornment for the neat algorithm as desribed in the papaer 
-/// these are very basic and are used to solve the xor problem for neat
+/// Default environment for the NEAT algorithm as described in the paper.
+///
+/// These are very basic and are used to solve the xor problem for NEAT.
 pub fn default_neat_env() -> NeatEnvironment {
     NeatEnvironment::new()
         .set_input_size(3)

--- a/radiate/src/models/README.md
+++ b/radiate/src/models/README.md
@@ -64,16 +64,16 @@ use radiate::prelude::*;
 
 fn main() -> Result<(), Box<dyn Error>> {
 
-    // set up a timer just to see how long it takes. Then define a NEATEnviornment to give
+    // set up a timer just to see how long it takes. Then define a NeatEnvironment to give
     // parameters to how the NEAT algorithm will be evolved. This controls how weights are edited,
     // how neurons are added, how connections are added, and which activation functions to use in hidden neurons
     let thread_time = Instant::now();
     let neat_env = NeatEnvironment::new()
         .set_weight_mutate_rate(0.8)        // 80% chance that the weights will be mutated, 20% change the weights will not be changed at all
         .set_edit_weights(0.1)              // 10% change that a weight will be assigned a new random number, 90% change it will be mutated by +/- weight_perturb
-        .set_weight_perturb(1.7)            // if a weight is selected to be mutated, mutliply the original weight by +/- 1.7 (shouldn't be larger than 2.0)
+        .set_weight_perturb(1.7)            // if a weight is selected to be mutated, multiply the original weight by +/- 1.7 (shouldn't be larger than 2.0)
         .set_new_node_rate(0.4)             // if the layer is LSTM or dense_pool, 40% chance a new hidden neuron will be added
-        .set_recurrent_neuron_rate(1.0)     // *v1.1.52* for every new neuron added, the % chance is recurrent 1.0 meaning 100%, 0.0 meaning 0% (not compatable with backprop)
+        .set_recurrent_neuron_rate(1.0)     // *v1.1.52* for every new neuron added, the % chance is recurrent 1.0 meaning 100%, 0.0 meaning 0% (not compatible with backprop)
         .set_new_edge_rate(0.4)             // if the layer is LSTM or dense_pool, 40% chance a new connection will be added between two random neurons with a random weight
         .set_reactivate(0.2)                // if the layer is LSTM or dense_pool, 20% chance a deactivated connection will be reactivated
         .set_activation_functions(vec![     // when new neurons are added, a random activation function is chosen from this list to give to the neuron

--- a/radiate/src/models/README.md
+++ b/radiate/src/models/README.md
@@ -25,8 +25,8 @@ Define a new Neat network with multiple layers
     let neural_network = Neat::new()
         .input_size(1)
         .dense(5, Activation::Relu)
-        .dense(5, Activation::Tahn)
-        .gru(10, 10, Activation::Tahn)          // (memory size, output size, output layer activation)
+        .dense(5, Activation::Tanh)
+        .gru(10, 10, Activation::Tanh)          // (memory size, output size, output layer activation)
         .dense_pool(1, Activation::Sigmoid);
 ```
 NEAT currently has four layer types that can be chained onto a neat instance. 
@@ -43,7 +43,7 @@ All neural networks need nonlinear functions to represent complex datasets. Neat
 ```rust
 pub enum Activation {
     Sigmoid,
-    Tahn,
+    Tanh,
     Relu,
     Softmax,       // Cannot be used on hidden neurons
     LeakyRelu(f32),

--- a/radiate/src/models/neat/edge.rs
+++ b/radiate/src/models/neat/edge.rs
@@ -35,7 +35,7 @@ impl Edge {
 
     /// update the weight of this edge connection
     #[inline]
-    pub fn update(&mut self, delta: f32, nodes: &mut Vec<Neuron>) {
+    pub fn update(&mut self, delta: f32, nodes: &mut [Neuron]) {
         self.update_weight(self.weight + delta, nodes);
     }
 
@@ -46,19 +46,19 @@ impl Edge {
     }
 
     /// update weight
-    pub fn update_weight(&mut self, weight: f32, nodes: &mut Vec<Neuron>) {
+    pub fn update_weight(&mut self, weight: f32, nodes: &mut [Neuron]) {
         self.weight = weight;
         nodes.get_mut(self.dst.index()).map(|x| x.update_incoming(self, weight));
     }
 
     /// Link edge src/dst nodes
-    pub fn link_nodes(&self, nodes: &mut Vec<Neuron>) {
+    pub fn link_nodes(&self, nodes: &mut [Neuron]) {
         nodes.get_mut(self.src.index()).map(|x| x.add_outgoing(self.id));
         nodes.get_mut(self.dst.index()).map(|x| x.add_incoming(self));
     }
 
     /// Enable edge and link the nodes.
-    pub fn enable(&mut self, nodes: &mut Vec<Neuron>) {
+    pub fn enable(&mut self, nodes: &mut [Neuron]) {
         if self.active {
             // already active, nothing to do.
             return;
@@ -71,7 +71,7 @@ impl Edge {
     }
 
     /// Disable edge and unlink the nodes.
-    pub fn disable(&mut self, nodes: &mut Vec<Neuron>) {
+    pub fn disable(&mut self, nodes: &mut [Neuron]) {
         self.active = false;
         nodes.get_mut(self.src.index()).map(|x| x.remove_outgoing(self.id));
         // For dst node, just set the weight to zero.

--- a/radiate/src/models/neat/layers/dense.rs
+++ b/radiate/src/models/neat/layers/dense.rs
@@ -142,7 +142,7 @@ impl Dense {
     }
 
     /// Add a node to the network by getting a random edge 
-    /// and inserting the new node inbetween that edge's source
+    /// and inserting the new node in-between that edge's source
     /// and destination nodes. The old weight is pushed forward 
     /// while the new weight is randomly chosen and put between the 
     /// old source node and the new node
@@ -605,7 +605,7 @@ impl Layer for Dense {
 
 
     /// Backpropagation algorithm, transfer the error through the network and change the weights of the
-    /// edges accordinly, this is pretty straight forward due to the design of the neat graph
+    /// edges accordingly, this is pretty straightforward due to the design of the neat graph
     fn backward(&mut self, error: &Vec<f32>, learning_rate: f32) -> Option<Vec<f32>> {
         // feed forward the input data to get the output in order to compute the error of the network
         // create a dfs stack to step backwards through the network and compute the error of each neuron
@@ -630,14 +630,14 @@ impl Layer for Dense {
                 None => curr_error * curr_node.deactivated_value
             } * learning_rate;
 
-            // reset the nodes error if it isnt an input node 
+            // reset the nodes error if it isn't an input node
             if curr_node.neuron_type != NeuronType::Input {
                 curr_node.bias += learning_rate * curr_error;
                 curr_node.error = 0.0;
             }
 
-            // iterate through each of the incoming edes to this neuron and adjust it's weight
-            // and add it's error to the errros map
+            // iterate through each of the incoming edges to this neuron and adjust its weight
+            // and add its error to the errors map
             for edge in curr_node.incoming_edges().iter() {
                 edge_updates.push(edge.id);
             }
@@ -653,7 +653,7 @@ impl Layer for Dense {
                     let src_neuron = self.nodes.get_mut(curr_edge.src.index())?;
                     src_neuron.error += curr_edge.weight * curr_error;
 
-                    // add the weight step (gradient) * the currnet value to the weight to adjust the weight
+                    // add the weight step (gradient) * the current value to the weight to adjust the weight
                     // then update the connection so it knows if it should update the weight, or store the delta
                     let delta = match &self.trace_states {
                         Some(tracer) => step * tracer.neuron_activation(src_neuron.id),
@@ -736,16 +736,16 @@ impl Genome<Dense, NeatEnvironment> for Dense
         let mut r = rand::thread_rng();
         if r.gen::<f32>() < crossover_rate {
             for edge in new_child.edges.iter_mut() {
-                // if the edge is in both networks, then radnomly assign the weight to the edge
+                // if the edge is in both networks, then randomly assign the weight to the edge
                 // because we are already looping over the most fit parent, we only need to change the 
-                // weight to the second parent if nessesary.
+                // weight to the second parent if necessary.
                 if let Some(parent_edge) = parent_two.get_edge_by_innov(&edge.innov) {
                     if r.gen::<f32>() < 0.5 {
                         edge.update_weight(parent_edge.weight, &mut new_child.nodes);
                     }
 
                     // if the edge is deactivated in either network and a random number is less than the 
-                    // reactivate parameter, then reactiveate the edge and insert it back into the network
+                    // reactivate parameter, then reactivate the edge and insert it back into the network
                     if (!edge.active || !parent_edge.active) && r.gen::<f32>() < set.reactivate? {
                         edge.enable(&mut new_child.nodes);
                     }

--- a/radiate/src/models/neat/layers/dense.rs
+++ b/radiate/src/models/neat/layers/dense.rs
@@ -352,7 +352,7 @@ impl Dense {
     }
 
 
-    fn fast_forward(&mut self, data: &Vec<f32>) -> Option<Vec<f32>> {
+    fn fast_forward(&mut self, data: &[f32]) -> Option<Vec<f32>> {
         let in_size = self.inputs.len();
 
         // First phase: update input neurons

--- a/radiate/src/models/neat/layers/gru.rs
+++ b/radiate/src/models/neat/layers/gru.rs
@@ -47,7 +47,7 @@ impl GRU {
             current_memory: vec![0.0; memory_size as usize],
             current_output: vec![0.0; output_size as usize],
             f_gate: Dense::new(network_in_size, memory_size, LayerType::DensePool, Activation::Sigmoid),
-            e_gate: Dense::new(network_in_size, memory_size, LayerType::DensePool, Activation::Tahn),
+            e_gate: Dense::new(network_in_size, memory_size, LayerType::DensePool, Activation::Tanh),
             o_gate: Dense::new(network_in_size, output_size, LayerType::DensePool, act),
         }
     }

--- a/radiate/src/models/neat/layers/layer.rs
+++ b/radiate/src/models/neat/layers/layer.rs
@@ -32,13 +32,13 @@ pub trait Layer: LayerClone + Any + Debug + Send + Sync {
     /// so the user only needs the say the size of the output, not the input. That would be too redundant.
     fn shape(&self) -> (usize, usize);
 
-    /// reset the layer, not a nessesary implementation
+    /// reset the layer, not a necessary implementation
     fn reset(&mut self) { }
 
     // add tracers to keep track of meta data for historical back propagation
     fn add_tracer(&mut self) { }
 
-    /// remove the tracer from a layer so that it can be evolved without keeping grack of data
+    /// remove the tracer from a layer so that it can be evolved without keeping track of data
     fn remove_tracer(&mut self) { }
 
 }
@@ -67,7 +67,7 @@ impl<L> LayerClone for L
 
 
 /// required for the dyn layer to be Clone in order for 
-/// LayerClone to work, so impelement Clone for any Layer
+/// LayerClone to work, so implement Clone for any Layer
 impl Clone for Box<dyn Layer> {
     fn clone(&self) -> Box<dyn Layer> {
         self.clone_box()

--- a/radiate/src/models/neat/layers/lstm.rs
+++ b/radiate/src/models/neat/layers/lstm.rs
@@ -108,9 +108,9 @@ impl LSTM {
 
 
 
-    /// feed forward with each forward propagation being executed in a seperate thread to speed up 
-    /// the forward pass if the network is NOT being evolved, if it is, there are already so many theads
-    /// working to optimize the entire population that extra threading is obsolute and might actually slow it down
+    /// Feed forward with each forward propagation being executed in a separate thread to speed up
+    /// the forward pass if the network is NOT being evolved. If it is, there are already so many threads
+    /// working to optimize the entire population that extra threading is unnecessary and might actually slow it down
     #[inline]
     pub fn step_forward_async(&mut self, inputs: &Vec<f32>) -> Option<Vec<f32>> {
         // get the previous state and output and create the input to the layer
@@ -162,7 +162,7 @@ impl LSTM {
 
 
 
-    /// step forward syncronously
+    /// step forward synchronously
     #[inline]
     pub fn step_forward(&mut self, inputs: &Vec<f32>) -> Option<Vec<f32>> {
         // get the previous state and output and create the input to the layer
@@ -195,8 +195,8 @@ impl LSTM {
 
 
     /// Preform one step backwards for the layer. Set the tracer historical meta data to look at the current
-    /// index, and use that data to compute the gradient steps for eachweight in each gated network. 
-    /// If update is true, the gates will take the accumulated gradient steps, and add them to their respecive weight values
+    /// index, and use that data to compute the gradient steps for each weight in each gated network.
+    /// If update is true, the gates will take the accumulated gradient steps, and add them to their respective weight values
     #[inline]
     pub fn step_back(&mut self, errors: &Vec<f32>, l_rate: f32) -> Option<Vec<f32>> {
         // get the derivative of the cell and hidden state from the previous step as well as the previous memory state
@@ -296,8 +296,8 @@ impl Layer for LSTM {
 
     /// forward propagate inputs, if the model is being evolved don't spawn extra threads because
     /// it slows down the process by about double the original time. If the model is being trained
-    /// traditionally, step forward asynconously by spawnin a thread for each individual gate 
-    /// which results in speeds about double as a synconous thread.
+    /// traditionally, step forward asynchronously by spawning a thread for each individual gate
+    /// which results in speeds about double as a synchronous thread.
     #[inline]
     fn forward(&mut self, inputs: &Vec<f32>) -> Option<Vec<f32>> {
         if self.f_gate.read().map(|x| x.trace_states.is_some()).ok()? {
@@ -308,7 +308,7 @@ impl Layer for LSTM {
 
 
 
-    /// apply backpropagation through time asyncronously because this is not done during evolution
+    /// apply backpropagation through time asynchronously because this is not done during evolution
     #[inline]
     fn backward(&mut self, errors: &Vec<f32>, learning_rate: f32) -> Option<Vec<f32>> {
         if self.states.d_prev_hidden.is_none() && self.states.d_prev_memory.is_none() {

--- a/radiate/src/models/neat/layers/lstm.rs
+++ b/radiate/src/models/neat/layers/lstm.rs
@@ -98,7 +98,7 @@ impl LSTM {
             memory: vec![0.0; memory_size as usize],
             hidden: vec![0.0; memory_size as usize],
             states: LSTMState::new(),
-            g_gate: Arc::new(RwLock::new(Dense::new(cell_input, memory_size, LayerType::DensePool, Activation::Tahn))),
+            g_gate: Arc::new(RwLock::new(Dense::new(cell_input, memory_size, LayerType::DensePool, Activation::Tanh))),
             i_gate: Arc::new(RwLock::new(Dense::new(cell_input, memory_size, LayerType::DensePool, Activation::Sigmoid))),
             f_gate: Arc::new(RwLock::new(Dense::new(cell_input, memory_size, LayerType::DensePool, Activation::Sigmoid))),
             o_gate: Arc::new(RwLock::new(Dense::new(cell_input, memory_size, LayerType::DensePool, Activation::Sigmoid))),
@@ -149,7 +149,7 @@ impl LSTM {
         vectorops::element_multiply(&mut self.memory, &f_curr);
         vectorops::element_multiply(&mut curr_state, &i_curr);
         vectorops::element_add(&mut self.memory, &curr_state);
-        vectorops::element_multiply(&mut curr_output, &vectorops::element_activate(&self.memory, Activation::Tahn));
+        vectorops::element_multiply(&mut curr_output, &vectorops::element_activate(&self.memory, Activation::Tanh));
 
         // update the state parameters only if the gates are traceable and the data needs to be collected
         self.states.update_forward(f_curr, i_curr, g_out, o_out, self.memory.clone());   
@@ -184,7 +184,7 @@ impl LSTM {
         vectorops::element_multiply(&mut self.memory, &f_output);
         vectorops::element_multiply(&mut current_state, &i_output);
         vectorops::element_add(&mut self.memory, &current_state);
-        vectorops::element_multiply(&mut current_output, &vectorops::element_activate(&self.memory, Activation::Tahn));
+        vectorops::element_multiply(&mut current_output, &vectorops::element_activate(&self.memory, Activation::Tanh));
 
         // return the output of the layer
         // keep track of the memory and the current output and the current state
@@ -219,7 +219,7 @@ impl LSTM {
         // Gradient for ho in h = ho * tanh(c)     
         //dho = tanh(c) * dh
         //dho = dsigmoid(ho) * dho
-        let mut dho = vectorops::element_activate(&c_old, Activation::Tahn);
+        let mut dho = vectorops::element_activate(&c_old, Activation::Tanh);
         vectorops::element_multiply(&mut dho, &dh);
         vectorops::element_multiply(&mut dho, &vectorops::element_deactivate(&o_curr, self.o_gate.read().unwrap().activation));
         let o_gate_clone = Arc::clone(&self.o_gate);
@@ -231,7 +231,7 @@ impl LSTM {
         // dc = ho * dh * dtanh(c)
         // dc = dc + dc_next
         let mut dc = vectorops::product(&o_curr, &dh);
-        vectorops::element_multiply(&mut dc, &vectorops::element_deactivate(&c_old, Activation::Tahn));
+        vectorops::element_multiply(&mut dc, &vectorops::element_deactivate(&c_old, Activation::Tanh));
         vectorops::element_add(&mut dc, &dc_next);
 
         // Gradient for hf in c = hf * c_old + hi * hc    

--- a/radiate/src/models/neat/layers/lstm.rs
+++ b/radiate/src/models/neat/layers/lstm.rs
@@ -112,7 +112,7 @@ impl LSTM {
     /// the forward pass if the network is NOT being evolved. If it is, there are already so many threads
     /// working to optimize the entire population that extra threading is unnecessary and might actually slow it down
     #[inline]
-    pub fn step_forward_async(&mut self, inputs: &Vec<f32>) -> Option<Vec<f32>> {
+    pub fn step_forward_async(&mut self, inputs: &[f32]) -> Option<Vec<f32>> {
         // get the previous state and output and create the input to the layer
         let mut hidden_input = self.hidden.clone();
         hidden_input.extend(inputs);
@@ -164,7 +164,7 @@ impl LSTM {
 
     /// step forward synchronously
     #[inline]
-    pub fn step_forward(&mut self, inputs: &Vec<f32>) -> Option<Vec<f32>> {
+    pub fn step_forward(&mut self, inputs: &[f32]) -> Option<Vec<f32>> {
         // get the previous state and output and create the input to the layer
         // let mut previous_state = &mut self.memory;
         let mut hidden_input = self.hidden.clone();

--- a/radiate/src/models/neat/layers/vectorops.rs
+++ b/radiate/src/models/neat/layers/vectorops.rs
@@ -7,7 +7,7 @@ use super::super::{
 
 /// multiply two vectors element-wise
 #[inline]
-pub fn element_multiply(one: &mut Vec<f32>, two: &Vec<f32>) {
+pub fn element_multiply(one: &mut [f32], two: &[f32]) {
     assert!(one.len() == two.len(), "Element multiply vector shapes don't match");
     one.iter_mut()
         .zip(two.iter())
@@ -20,7 +20,7 @@ pub fn element_multiply(one: &mut Vec<f32>, two: &Vec<f32>) {
 
 /// invert a vector that is already holding values between 0 and 1
 #[inline]
-pub fn element_invert(one: &mut Vec<f32>) {
+pub fn element_invert(one: &mut [f32]) {
     one.iter_mut()
         .for_each(|a| *a = 1.0 - *a);
 }
@@ -29,7 +29,7 @@ pub fn element_invert(one: &mut Vec<f32>) {
 
 /// add elements from vectors together element-wise
 #[inline]
-pub fn element_add(one: &mut Vec<f32>, two: &Vec<f32>) {
+pub fn element_add(one: &mut [f32], two: &[f32]) {
     assert!(one.len() == two.len(), "Element add vector shapes don't match");
     one.iter_mut()
         .zip(two.iter())
@@ -40,7 +40,7 @@ pub fn element_add(one: &mut Vec<f32>, two: &Vec<f32>) {
 
 
 #[inline]
-pub fn element_activate(one: &Vec<f32>, func: Activation) -> Vec<f32> {
+pub fn element_activate(one: &[f32], func: Activation) -> Vec<f32> {
     one.iter()
         .map(|x| {
             func.activate(*x)
@@ -50,7 +50,7 @@ pub fn element_activate(one: &Vec<f32>, func: Activation) -> Vec<f32> {
 
 
 #[inline]
-pub fn element_deactivate(one: &Vec<f32>, func: Activation) -> Vec<f32> {
+pub fn element_deactivate(one: &[f32], func: Activation) -> Vec<f32> {
     one.iter()
         .map(|x| {
             func.deactivate(*x)
@@ -60,7 +60,7 @@ pub fn element_deactivate(one: &Vec<f32>, func: Activation) -> Vec<f32> {
 
 
 #[inline]
-pub fn product(one: &Vec<f32>, two: &Vec<f32>) -> Vec<f32> {
+pub fn product(one: &[f32], two: &[f32]) -> Vec<f32> {
     assert!(one.len() == two.len(), "Product dimensions do not match");
     one.iter()
         .zip(two.iter())
@@ -70,7 +70,7 @@ pub fn product(one: &Vec<f32>, two: &Vec<f32>) -> Vec<f32> {
 
 
 #[inline]
-pub fn subtract(one: &Vec<f32>, two: &Vec<f32>) -> Vec<f32> {
+pub fn subtract(one: &[f32], two: &[f32]) -> Vec<f32> {
     assert!(one.len() == two.len(), "Subtract lengths do not match");
     one.iter()
         .zip(two.iter())
@@ -80,7 +80,7 @@ pub fn subtract(one: &Vec<f32>, two: &Vec<f32>) -> Vec<f32> {
 
 
 #[inline]
-pub fn softmax(one: &Vec<f32>) -> Vec<f32> {
+pub fn softmax(one: &[f32]) -> Vec<f32> {
     let ex = one   
         .iter()
         .map(|x| x.exp())
@@ -93,7 +93,7 @@ pub fn softmax(one: &Vec<f32>) -> Vec<f32> {
 
 
 #[inline]
-pub fn d_softmax(one: &Vec<f32>) -> Vec<f32> {
+pub fn d_softmax(one: &[f32]) -> Vec<f32> {
     one.iter()
         .map(|x| x - 1.0)
         .collect()
@@ -102,7 +102,7 @@ pub fn d_softmax(one: &Vec<f32>) -> Vec<f32> {
 
 
 #[inline]
-pub fn loss(one: &Vec<f32>, two: &Vec<f32>, loss_fn: &Loss) -> (f32, Vec<f32>) {
+pub fn loss(one: &[f32], two: &[f32], loss_fn: &Loss) -> (f32, Vec<f32>) {
     assert!(one.len() == two.len(), "Loss vector shape don't match");
     match loss_fn {
         Loss::Diff => {

--- a/radiate/src/models/neat/layers/vectorops.rs
+++ b/radiate/src/models/neat/layers/vectorops.rs
@@ -5,7 +5,7 @@ use super::super::{
 };
 
 
-/// multiply two vectors element wise
+/// multiply two vectors element-wise
 #[inline]
 pub fn element_multiply(one: &mut Vec<f32>, two: &Vec<f32>) {
     assert!(one.len() == two.len(), "Element multiply vector shapes don't match");
@@ -27,7 +27,7 @@ pub fn element_invert(one: &mut Vec<f32>) {
 
 
 
-/// add elements from vectors together element wise
+/// add elements from vectors together element-wise
 #[inline]
 pub fn element_add(one: &mut Vec<f32>, two: &Vec<f32>) {
     assert!(one.len() == two.len(), "Element add vector shapes don't match");

--- a/radiate/src/models/neat/mod.rs
+++ b/radiate/src/models/neat/mod.rs
@@ -33,10 +33,11 @@ pub mod activation {
 
     use std::f32::consts::E as Eul;
 
-    /// Varius activation functions for a neuron, must be specified at creation
+    /// Various activation functions for a neuron, must be specified at creation
     #[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Copy)]
     pub enum Activation {
         Sigmoid,
+        // TODO: Fix name and deprecate
         Tahn,
         Relu,
         Softmax,
@@ -49,7 +50,7 @@ pub mod activation {
     impl Activation {
 
         /// Generic activation functions for an neural network - note for a few
-        /// of these an alpha parameter is needed when first assining the function
+        /// of these an alpha parameter is needed when first assigning the function
         #[inline]
         pub fn activate(&self, x: f32) -> f32 {
             match self {

--- a/radiate/src/models/neat/mod.rs
+++ b/radiate/src/models/neat/mod.rs
@@ -29,6 +29,7 @@ pub mod loss {
 }
 
 
+#[allow(deprecated)]
 pub mod activation {
 
     use std::f32::consts::E as Eul;
@@ -37,7 +38,9 @@ pub mod activation {
     #[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Copy)]
     pub enum Activation {
         Sigmoid,
-        // TODO: Fix name and deprecate
+        Tanh,
+        #[doc(hidden)]
+        #[deprecated = "Use `Tanh`"]
         Tahn,
         Relu,
         Softmax,
@@ -57,7 +60,7 @@ pub mod activation {
                 Self::Sigmoid => {
                     1.0 / (1.0 + (-x * 4.9).exp())
                 },
-                Self::Tahn => {
+                Self::Tanh | Self::Tahn => {
                     x.tanh()
                 },
                 Self::Relu => { 
@@ -97,7 +100,7 @@ pub mod activation {
                 Self::Sigmoid => {
                     self.activate(x) * (1.0 - self.activate(x))
                 },
-                Self::Tahn => {
+                Self::Tanh | Self::Tahn => {
                     1.0 - (self.activate(x)).powf(2.0)
                 },
                 Self::Linear(alpha) => {

--- a/radiate/src/models/neat/neat.rs
+++ b/radiate/src/models/neat/neat.rs
@@ -95,7 +95,7 @@ impl Neat {
 
     /// train the network
     #[inline]
-    pub fn train<F>(&mut self, inputs: &Vec<Vec<f32>>, targets: &Vec<Vec<f32>>, rate: f32, loss_fn: Loss, run: F) -> Result<(), Box<dyn Error>> 
+    pub fn train<F>(&mut self, inputs: &[Vec<f32>], targets: &[Vec<f32>], rate: f32, loss_fn: Loss, run: F) -> Result<(), Box<dyn Error>>
         where F: Fn(usize, f32) -> bool 
     {
         // make sure the data actually can be fed through
@@ -146,7 +146,7 @@ impl Neat {
 
     /// backpropagate the network, will move through time if needed
     #[inline]
-    pub fn backward(&mut self, net_outs: &Vec<Vec<f32>>, net_targets: &Vec<Vec<f32>>, rate: f32, loss_fn: &Loss) -> f32 {
+    pub fn backward(&mut self, net_outs: &[Vec<f32>], net_targets: &[Vec<f32>], rate: f32, loss_fn: &Loss) -> f32 {
         let mut total_loss = 0.0;
         for i in (0..net_outs.len()).rev() {
             let errors = vectorops::loss(&net_targets[i], &net_outs[i], &loss_fn);
@@ -175,7 +175,7 @@ impl Neat {
             data_transfer = &temp;
         }
         // gather the output and return it as an option
-        Some(data_transfer.clone())
+        Some(data_transfer.to_owned())
     }    
 
 

--- a/radiate/src/models/neat/neat.rs
+++ b/radiate/src/models/neat/neat.rs
@@ -144,7 +144,7 @@ impl Neat {
 
     
 
-    /// backpropagate the network, will move throgh time if needed
+    /// backpropagate the network, will move through time if needed
     #[inline]
     pub fn backward(&mut self, net_outs: &Vec<Vec<f32>>, net_targets: &Vec<Vec<f32>>, rate: f32, loss_fn: &Loss) -> f32 {
         let mut total_loss = 0.0;
@@ -235,7 +235,7 @@ impl Neat {
 
     
 
-    /// in order to more efficently give inputs to the network, this function simple 
+    /// in order to more efficiently give inputs to the network, this function simple
     /// finds the shape of the layer that should be created based on the desired size
     #[inline]
     fn get_layer_sizes(&self, size: u32) -> Option<(u32, u32)> {
@@ -300,7 +300,7 @@ impl PartialEq for Neat {
 
 
 
-/// iplement genome for a neat network
+/// implement genome for a neat network
 impl Genome<Neat, NeatEnvironment> for Neat {
 
     #[inline]

--- a/radiate/src/models/neat/neatenv.rs
+++ b/radiate/src/models/neat/neatenv.rs
@@ -4,7 +4,7 @@ use super::activation::Activation;
 use crate::engine::environment::Envionment;
 
 
-/// Configuation settings for the NeatAlgorithm 
+/// Configuration settings for the NeatAlgorithm
 /// 
 /// weight_mutate_rate: the probability of uniformly perturbing a connection weight or assigning a new random value
 /// weight_perturb: the uniform range to perturb a weight by will go from negative num to pos (if you enter 5, it will pertub a weight randomly between -5 and 5)

--- a/radiate/src/models/neat/neuron.rs
+++ b/radiate/src/models/neat/neuron.rs
@@ -28,8 +28,8 @@ impl NeuronLink {
 }
 
 /// Neuron is a wrapper around a neuron providing only what is needed for a neuron to be added 
-/// to the NEAT graph, while the neuron encapsulates the neural network logic for the specific nodetype,
-/// Some neurons like an LSTM require more variables and different interal activation logic, 
+/// to the NEAT graph, while the neuron encapsulates the neural network logic for the specific node type,
+/// Some neurons like an LSTM require more variables and different internal activation logic,
 /// so encapsulating that within a normal node on the graph would be misplaced.
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Neuron {
@@ -124,7 +124,7 @@ impl Neuron {
 
 
     /// each Neuron has a base layer of reset which needs to happen 
-    /// but on top of that each neuron might need to do more interanally
+    /// but on top of that each neuron might need to do more internally
     #[inline]
     pub fn reset_neuron(&mut self) {
         self.error = 0.0;

--- a/radiate/src/models/neat/tracer.rs
+++ b/radiate/src/models/neat/tracer.rs
@@ -60,7 +60,7 @@ impl Tracer {
 
 
 
-    /// update a neruon and add it's derivative of it's activated value to the tracer 
+    /// update a neuron and add it's derivative of it's activated value to the tracer
     pub fn update_neuron_derivative(&mut self, neuron_id: &NeuronId, neuron_d: f32) {
         if self.neuron_derivative.contains_key(&neuron_id) {
             let states = self.neuron_derivative.get_mut(&neuron_id).unwrap();

--- a/radiate/src/prelude.rs
+++ b/radiate/src/prelude.rs
@@ -1,3 +1,3 @@
 /// easily import all structs and traits 
-/// into whereever the prelude is imported
+/// into wherever the prelude is imported
 pub use super::*;

--- a/radiate/tests/helloworld.rs
+++ b/radiate/tests/helloworld.rs
@@ -89,7 +89,7 @@ pub struct Hello {
 }
 
 impl Hello {
-    pub fn new(alph: &Vec<char>) -> Self {
+    pub fn new(alph: &[char]) -> Self {
         let mut r = rand::thread_rng();
         Hello { data: (0..12).map(|_| alph[r.gen_range(0, alph.len())]).collect() }
     }

--- a/radiate_matrix_tree/Cargo.toml
+++ b/radiate_matrix_tree/Cargo.toml
@@ -2,7 +2,7 @@
 name = "radiate_matrix_tree"
 version = "1.0.2"
 authors = ["pkalivas <peterkalivas@gmail.com>"]
-description = "Matrix Tree model compatable with Radiate's evolutionary engine"
+description = "Matrix Tree model compatible with Radiate's evolutionary engine"
 repository = "https://github.com/pkalivas/radiate"
 readme = "README.md"
 categories = ["science", "simulation", "algorithms", "evolve", "genetic"]

--- a/radiate_matrix_tree/README.md
+++ b/radiate_matrix_tree/README.md
@@ -1,7 +1,7 @@
 
 ## Radiate Matrix Tree
 
-This is a pre-built model which is compatable with [Radiate](https://crates.io/crates/radiate), a parallel evoltuionary engine. 
+This is a pre-built model which is compatible with [Radiate](https://crates.io/crates/radiate), a parallel evolutionary engine.
 
 ### Evtree
 Is a twist on decision trees where instead of using a certain split criteria like the gini index, each node in the tree has a collection of matrices and uses these matrices to decide which subtree to explore. It is a binary tree and is only good for classification right now. 

--- a/radiate_matrix_tree/src/lib.rs
+++ b/radiate_matrix_tree/src/lib.rs
@@ -20,8 +20,7 @@ pub use matrix_tree::{
 /// get a default environment settings for evtree, these are very basic and 
 /// are used to solve the xor problem. These are just settings to evolve the
 /// tree, more can be added or taken away depending on the desired problem to solve
-// TODO: Fix name, deprecate
-pub fn defualt_evtree_env() -> TreeEnvionment {
+pub fn default_evtree_env() -> TreeEnvionment {
     TreeEnvionment::new()
         .set_input_size(2)
         .set_outputs(vec![0, 1])
@@ -34,4 +33,10 @@ pub fn defualt_evtree_env() -> TreeEnvionment {
         .set_layer_mutate_rate(0.8)
         .set_weight_mutate_rate(0.8)
         .set_weight_transform_rate(5.0)
+}
+
+#[doc(hidden)]
+#[deprecated = "Use `default_evtree_env`"]
+pub fn defualt_evtree_env() -> TreeEnvionment {
+    default_evtree_env()
 }

--- a/radiate_matrix_tree/src/lib.rs
+++ b/radiate_matrix_tree/src/lib.rs
@@ -18,8 +18,9 @@ pub use matrix_tree::{
 };
 
 /// get a default environment settings for evtree, these are very basic and 
-/// are used to solve the xor problem. These are just settings to evolve thre
+/// are used to solve the xor problem. These are just settings to evolve the
 /// tree, more can be added or taken away depending on the desired problem to solve
+// TODO: Fix name, deprecate
 pub fn defualt_evtree_env() -> TreeEnvionment {
     TreeEnvionment::new()
         .set_input_size(2)

--- a/radiate_matrix_tree/src/matrix_tree/evenv.rs
+++ b/radiate_matrix_tree/src/matrix_tree/evenv.rs
@@ -85,7 +85,7 @@ impl TreeEnvionment {
     }
 
     #[allow(dead_code)]
-    pub fn get_outputs(&self) -> &Vec<i32> {
+    pub fn get_outputs(&self) -> &[i32] {
         self.outputs.as_ref().unwrap_or_else(|| panic!("Outputs not set"))
     }
 

--- a/radiate_matrix_tree/src/matrix_tree/evtree.rs
+++ b/radiate_matrix_tree/src/matrix_tree/evtree.rs
@@ -35,7 +35,7 @@ impl NetNode {
     /// From the list of output_options the node will choose an output,
     /// from the input_size the node will create a randomly generated 
     /// neural network.
-    pub fn new(input_size: i32, output_options: &Vec<i32>) -> Self {
+    pub fn new(input_size: i32, output_options: &[i32]) -> Self {
         let mut r = rand::thread_rng();
         let output = output_options[r.gen_range(0, output_options.len())] as u8;
         Self {

--- a/radiate_matrix_tree/src/tree/mod.rs
+++ b/radiate_matrix_tree/src/tree/mod.rs
@@ -16,7 +16,7 @@ pub use node::{Node, Link};
 /// 
 /// This struct holds the root of the tree. The tree also contains a size which represents the number of nodes in the tree,
 /// an input size which is the size of the input vector (1D), and is used to generate nodes alone with the 
-/// output options which is an owned vec of i32s represnting different outputs of the classification.
+/// output options which is an owned vec of i32s representing different outputs of the classification.
 #[derive(PartialEq)]
 pub struct Tree<T: Clone> {
     root: Link<T>,
@@ -63,7 +63,7 @@ impl<T: Clone> Tree<T> {
 
     /// return an in order iterator which 
     /// allows for the nodes in the tree to be
-    /// mutatued while iterating
+    /// mutated while iterating
     pub fn iter_mut(&mut self) -> iterators::IterMut<'_, T> {
         iterators::IterMut::new(self.root_mut_opt())
     }
@@ -249,7 +249,7 @@ impl<T: Clone> Tree<T> {
         self.update_size();
     }
 
-    /// Shuffel the tree by gathering a list of the nodes then shuffling the list
+    /// Shuffle the tree by gathering a list of the nodes then shuffling the list
     /// and then balancing the tree again from that list
     #[inline]    
     pub fn shuffle_tree(&mut self, r: &mut ThreadRng) {
@@ -269,7 +269,7 @@ impl<T: Clone> fmt::Debug for Tree<T> {
 }
 
 /// Return a new copy of the tree, calling deep copy from the root node and copying over
-/// the size, input size, and output options in the most effecient way.
+/// the size, input size, and output options in the most efficient way.
 impl<T: Clone> Clone for Tree<T> {
     #[inline]
     fn clone(&self) -> Self {
@@ -285,23 +285,23 @@ impl<T: Clone> Clone for Tree<T> {
 /// Because the tree is made out of raw mutable pointers, if those pointers
 /// are not dropped, there is a severe memory leak, like possibly gigs of
 /// ram over only a few generations depending on the size of the generation
-/// This drop implementation will recursivley drop all nodes in the tree 
+/// This drop implementation will recursively drop all nodes in the tree
 impl<T: Clone> Drop for Tree<T> {
     fn drop(&mut self) { 
         self.drop_root();
     }
 }
 
-/// These must be implemneted for the tree or any type to be 
-/// used within seperate threads. Because implementing the functions 
-/// themselves is dangerious and unsafe and i'm not smart enough 
-/// to do that from scratch, these "implmenetaions" will get rid 
-/// of the error and realistically they don't need to be implemneted for the
+/// These must be implemented for the tree or any type to be
+/// used within separate threads. Because implementing the functions
+/// themselves is dangerous and unsafe and i'm not smart enough
+/// to do that from scratch, these "implementations" will get rid
+/// of the error and realistically they don't need to be implemented for the
 /// program to work
 unsafe impl<T: Clone> Send for Tree<T> {}
 unsafe impl<T: Clone> Sync for Tree<T> {}
 
-/// implement a function for getting a base default Tree which is completetly empty
+/// implement a function for getting a base default Tree which is completely empty
 /// There are multiple places within the struct implementation which will panic! if 
 /// this default Tree is passed through it.
 impl<T: Clone> Default for Tree<T> {

--- a/radiate_matrix_tree/src/tree/node.rs
+++ b/radiate_matrix_tree/src/tree/node.rs
@@ -207,7 +207,7 @@ impl<T: Clone> Node<T> {
         }
     }
 
-    /// return the height of this node recursivley
+    /// return the height of this node recursively
     #[inline]    
     pub fn height(&self) -> i32 {
         1 + max(
@@ -217,7 +217,7 @@ impl<T: Clone> Node<T> {
     }
 
     /// return the depth of this node, meaning the number of levels down it is 
-    /// from the root of the tree, recrsive.
+    /// from the root of the tree, recursively.
     #[inline]    
     pub fn depth(&self) -> i32 {
         match self.parent_opt() {
@@ -226,7 +226,7 @@ impl<T: Clone> Node<T> {
         }
     }
 
-    /// return the size of the subtree recrusivley. 
+    /// return the size of the subtree recursively.
     #[inline]    
     pub fn size(&self) -> i32 {
         let mut result = 1;
@@ -253,8 +253,8 @@ impl<T: Clone> Node<T> {
         })
     }
 
-    /// deep copy this node and it's subnodes. Recursivley traverse the tree in order and 
-    /// thin copy the current node, then assign it's surroudning pointers recrusivley.
+    /// deep copy this node and it's subnodes. Recursively traverse the tree in order and
+    /// thin copy the current node, then assign it's surrounding pointers recursively.
     #[inline]    
     pub fn deepcopy(&self) -> Box<Node<T>> {
         let mut temp_copy = self.copy();
@@ -291,8 +291,8 @@ impl<T: Clone> Node<T> {
         }
     }
 
-    /// Recrusively display the node and it's subnodes 
-    /// Useful for visualizing the strucutre of the tree and debugging.
+    /// Recursively display the node and it's subnodes
+    /// Useful for visualizing the structure of the tree and debugging.
     /// Level is the depth of the tree, at the root it should be 0.
     pub fn display(&self, level: i32) {
         if let Some(child) = self.left_child_opt() {
@@ -329,7 +329,7 @@ impl<T: Clone> PartialEq for Node<T> {
     }
 }
 
-/// implement debut for the node to give a little more information for the node and 
+/// implement `Debug` for the node to give a little more information for the node and
 /// make it easier to trace through a tree when a tree is displayed
 impl<T: Clone> fmt::Debug for Node<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/radiate_web/README.md
+++ b/radiate_web/README.md
@@ -1,11 +1,11 @@
 # Radiate Web
-Often trining deep learning alorithms is an expensive CPU/GPU action and with [Radiate](https://github.com/pkalivas/radiate) there is no exception. To aid in this problem, Radiate Web exposes a few data transfer objects to be able to build your learning algorithm remotely, then send it to another machine to train or test. This is a small extension that goes with [Radiate](https://github.com/pkalivas/radiate).
+Often, training deep learning algorithms is an expensive CPU/GPU operation and with [Radiate](https://github.com/pkalivas/radiate) this is no exception. To aid this problem, Radiate Web exposes a few data transfer objects to be able to build your learning algorithm remotely, then send it to another machine to train or test. This is a small extension that goes with [Radiate](https://github.com/pkalivas/radiate).
 
 ### Population Data Transfer Object (DTO)
 Simply build your transfer object to send over to your other machine by defining the parameters of a simple population. This does not allow you to define a few of the parameters, mainly the 'run' function which determines when to stop training and is required to be on the training machine. 
 
 ### Radiate Data Transfer Object
-Build a Radiate genetic algorithm with NEAT (Neuroeolution of Augmented Topologies) to send by encapuslating the rest of the training options and they're environment. 
+Build a Radiate genetic algorithm with NEAT (Neuroevolution of Augmented Topologies) to send by encapsulating the rest of the training options and their environment.
 
 ## Example
 This example code can be found [here](https://github.com/pkalivas/radiate/tree/master/examples/neat-web) which describes how the client and server are set up using [Rocket](https://rocket.rs/) and [Tokio](https://github.com/tokio-rs/tokio) to build a web service and handle the routing.


### PR DESCRIPTION
I went through everything quickly and fixed most of the many spelling errors, I believe, plus some other smaller doc improvements.

Misspelled parts of the API have been renamed (with the old one left over as deprecated to keep backwards compatibility).

There's also a refactoring in here: Using slices (`&[]`) instead of `&Vec` for input values, which is a general convention in Rust and more general since &Vec derefs to a slice automatically. Sadly I couldn't change this in the `Layer` trait as well since that would be a breaking change for users. I can add that as well if you like, though, the commit is done already.

There should be no breaking changes in this PR.