### PR TITLE
Add WebAssembly support

### DIFF
--- a/radiate/Cargo.toml
+++ b/radiate/Cargo.toml
@@ -15,6 +15,10 @@ license = "MIT"
 small-ids = []
 # Use u8 for Neuron Ids (256) and u32 for Edge Ids (256 * 256 = 65536)
 tiny-ids = []
+# Enable stdweb support (needed for uuid)
+stdweb = ["uuid/stdweb"]
+# Enable wasm-bindgen support
+wasm-bindgen = ["uuid/wasm-bindgen"]
 
 [dependencies]
 rand="0.7.2"


### PR DESCRIPTION
By default, uuid crate will not work on wasm targets.
This PR adds wasm-bindgen and stdweb features for uuid, so it can be compile for wasm targets.